### PR TITLE
Fix unresponsive modal buttons (Cancel/Quit/OK)

### DIFF
--- a/weight-tracker/index.html
+++ b/weight-tracker/index.html
@@ -581,7 +581,7 @@
 'use strict';
 
 /* ---------- State ---------- */
-const APP_VERSION = 'v5 · no preset weight';
+const APP_VERSION = 'v5 · modal fix';
 const STORAGE_KEY = 'wt-state-v2';
 let saveErrorShown = false;
 const DEFAULT_STATE = {
@@ -1649,7 +1649,7 @@ function renderModal() {
   }
   root.innerHTML = `
     <div class="modal-backdrop">
-      <div class="modal" onclick="event.stopPropagation()">
+      <div class="modal">
         <h3>${esc(modal.title)}</h3>
         ${modal.body ? `<p>${esc(modal.body)}</p>` : ''}
         <div class="btn-group">


### PR DESCRIPTION
## Summary

Modal buttons (Cancel, Quit, OK, Restart) weren't responding to taps. Root cause: the modal markup had inline `onclick="event.stopPropagation()"` on the `.modal` container, which blocked clicks from bubbling up to the document-level click handler that actually wires those buttons.

The stopPropagation was meant to prevent inner clicks from triggering the backdrop-close — but the backdrop-close handler already correctly gates on `e.target.classList.contains('modal-backdrop')`, so clicks on child content never matched it anyway. Inline handler removed.

This restores every modal in the app: Quit workout, End early, Restart program, Reset program, Add an exercise warning, save-error/storage-error dialogs.

## Test plan

- [ ] Merge, wait for Pages deploy, reload on phone. Confirm version stamp reads `v5 · modal fix`.
- [ ] Start any workout, tap the × in the header. Modal appears.
- [ ] Tap **Cancel** — modal closes, workout still running.
- [ ] Tap × again → tap **Quit** — workout is discarded, returns to Today.
- [ ] Bonus: tapping outside the modal (on the dark backdrop) still closes it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BW3wN8yik1X8Fpc4pkUZ7M)_