### PR TITLE
disable double-tap zoom and 300ms tap delay

### DIFF
--- a/weight-tracker/index.html
+++ b/weight-tracker/index.html
@@ -43,6 +43,7 @@
     line-height: 1.4;
     min-height: 100vh;
     overscroll-behavior-y: contain;
+    touch-action: manipulation;
   }
   #app {
     max-width: 640px;
@@ -764,7 +765,7 @@
 'use strict';
 
 /* ---------- State ---------- */
-const APP_VERSION = 'v9 · unified controls';
+const APP_VERSION = 'v10 · no double-tap zoom';
 const STORAGE_KEY = 'wt-state-v2';
 let saveErrorShown = false;
 const DEFAULT_STATE = {


### PR DESCRIPTION
Adds touch-action: manipulation to body so iOS Safari stops interpreting a quick second tap as a zoom gesture. Also removes the 300 ms tap delay Safari adds while it waits to see if a tap is the first of a double-tap, so set logging and other rapid interactions feel snappier. Pinch-to-zoom remains available for accessibility - this only disables the double-tap gesture, not all scaling. Bumps version stamp.