### PR TITLE
Seed exercise autocomplete with curated library of ~80 lifts

### DIFF
--- a/weight-tracker/index.html
+++ b/weight-tracker/index.html
@@ -765,7 +765,42 @@
 'use strict';
 
 /* ---------- State ---------- */
-const APP_VERSION = 'v10 · no double-tap zoom';
+const APP_VERSION = 'v11 · exercise library';
+
+const EXERCISE_LIBRARY = [
+  // Squat / quad
+  'Back Squat', 'Front Squat', 'Goblet Squat', 'Hack Squat', 'Bulgarian Split Squat',
+  'Leg Press', 'Lunge', 'Walking Lunge', 'Step-Up', 'Leg Extension',
+  // Hinge / posterior chain
+  'Deadlift', 'Romanian Deadlift', 'Sumo Deadlift', 'Stiff-Leg Deadlift',
+  'Hip Thrust', 'Glute Bridge', 'Good Morning', 'Leg Curl', 'Kettlebell Swing',
+  // Calves
+  'Standing Calf Raise', 'Seated Calf Raise',
+  // Push horizontal
+  'Bench Press', 'Incline Bench Press', 'Decline Bench Press', 'Close-Grip Bench Press',
+  'Dumbbell Bench Press', 'Incline Dumbbell Press', 'Dumbbell Fly', 'Cable Fly',
+  'Dumbbell Pullover', 'Push-Up', 'Diamond Push-Up', 'Dip',
+  // Pull horizontal
+  'Bent-Over Row', 'Pendlay Row', 'T-Bar Row', 'Seated Cable Row', 'Dumbbell Row',
+  'Inverted Row', 'Chest-Supported Row', 'Face Pull',
+  // Pull vertical
+  'Pull-Up', 'Chin-Up', 'Lat Pulldown', 'Straight-Arm Pulldown',
+  // Shoulders
+  'Overhead Press', 'Dumbbell Shoulder Press', 'Arnold Press', 'Push Press',
+  'Lateral Raise', 'Cable Lateral Raise', 'Front Raise', 'Rear Delt Fly',
+  'Upright Row', 'Shrug',
+  // Biceps
+  'Barbell Curl', 'EZ-Bar Curl', 'Dumbbell Curl', 'Hammer Curl',
+  'Preacher Curl', 'Cable Curl', 'Concentration Curl', 'Incline Dumbbell Curl',
+  // Triceps
+  'Tricep Pushdown', 'Skull Crusher', 'Overhead Tricep Extension',
+  'Tricep Dip', 'Tricep Kickback', 'Cable Overhead Extension',
+  // Core
+  'Plank', 'Side Plank', 'Hanging Leg Raise', 'Cable Crunch', 'Russian Twist',
+  'Ab Wheel Rollout', 'Sit-Up', 'Crunch', 'Mountain Climber', 'Pallof Press',
+  // Olympic / total body
+  'Power Clean', 'Clean and Press', 'Snatch', 'Farmer’s Walk', 'Turkish Get-Up'
+];
 const STORAGE_KEY = 'wt-state-v2';
 let saveErrorShown = false;
 const DEFAULT_STATE = {
@@ -1088,12 +1123,19 @@ function exEditorHtml(ex, j) {
 };
 
 function exerciseNameSuggestions() {
-  const set = new Set();
-  state.sessions.forEach(s => s.exercises.forEach(e => { if (e.name) set.add(e.name); }));
+  // lowercase key → display name. Library wins casing; user-entered names from
+  // sessions/template fill in anything the library doesn't already cover.
+  const map = new Map();
+  EXERCISE_LIBRARY.forEach(n => map.set(n.toLowerCase(), n));
+  state.sessions.forEach(s => s.exercises.forEach(e => {
+    if (e.name && !map.has(e.name.toLowerCase())) map.set(e.name.toLowerCase(), e.name);
+  }));
   if (state.program) {
-    state.program.template.forEach(d => d.exercises.forEach(e => { if (e.name) set.add(e.name); }));
+    state.program.template.forEach(d => d.exercises.forEach(e => {
+      if (e.name && !map.has(e.name.toLowerCase())) map.set(e.name.toLowerCase(), e.name);
+    }));
   }
-  return Array.from(set).sort((a, b) => a.localeCompare(b));
+  return Array.from(map.values()).sort((a, b) => a.localeCompare(b));
 }
 
 Views.today = function() {


### PR DESCRIPTION
## Summary

Seeds the exercise name autocomplete with a curated library of ~80 common lifts so the dropdown is populated from day one, not just from your own past sessions.

- New `EXERCISE_LIBRARY` constant covers the main movement patterns: squat, hinge, push (horizontal & vertical), pull (horizontal & vertical), shoulders, biceps, triceps, core, and total-body work.
- `exerciseNameSuggestions()` merges library + history + current template, deduping case-insensitively. Library casing wins over older lowercase entries.
- **Custom names still work** — typing anything not in the list saves as-is. No new picker UI to learn; the existing native datalist handles "type to filter / tap to pick / accept custom".

## How to use

1. In Edit Program, tap an exercise name input.
2. Start typing — the list narrows to matches.
3. Tap a suggestion to use the library spelling, or finish typing your own.

## Test plan

- [ ] Merge, wait for Pages deploy, reload. Version stamp reads `v11 · exercise library`.
- [ ] Edit Program → tap an exercise name input. Library suggestions appear (e.g. type "ben" → Bench Press, Incline Bench Press, …).
- [ ] Type a custom name like "Zercher Squat" — accepted as-is, saved with the program.
- [ ] If you have older sessions with lowercase entries (e.g. "bench press") and the library has "Bench Press", only the library casing should appear in the dropdown.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BW3wN8yik1X8Fpc4pkUZ7M)_