### PR TITLE
Implement Inline Dense workout view + modern set logger

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* ---------- State ---------- */
-const APP_VERSION = 'v19 · today stepper';
+const APP_VERSION = 'v20 · inline dense';
 
 const EXERCISE_LIBRARY = [
   // Squat / quad

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -1,78 +1,100 @@
 Views.workout = function() {
   const a = state.active;
-  const totalEx = a.exercises.length;
   const currentExIdx = a.exercises.findIndex(e => !exerciseIsResolved(e));
   const allDone = currentExIdx === -1;
-  const doneCount = a.exercises.filter(exerciseIsResolved).length;
+
+  const dots = a.exercises.map((e, i) => {
+    const done = exerciseIsComplete(e);
+    const skipped = !!e.skipped;
+    const cur = i === currentExIdx;
+    return `<div class="dot ${done ? 'done' : ''} ${skipped ? 'skipped' : ''} ${cur ? 'current' : ''}" data-jump="${i}"></div>`;
+  }).join('');
+
+  const steps = a.exercises.map((e, i) => exerciseRailStepHtml(e, i, currentExIdx)).join('');
 
   return `
     <div class="workout-top">
-      <div class="row">
-        <div>
-          <div class="subtle">Week ${a.weekIndex + 1} · ${esc(a.dayName)}</div>
-        </div>
+      <div style="margin-bottom:13px;">
+        <div class="section-label" style="margin-bottom:3px;">Week ${a.weekIndex + 1}</div>
+        <h1 class="workout-day-title">${esc(a.dayName)}</h1>
       </div>
-      <div class="dots">
-        ${a.exercises.map((e, i) => {
-          const done = exerciseIsComplete(e);
-          const skipped = !!e.skipped;
-          const cur = i === currentExIdx;
-          return `<div class="dot ${done ? 'done' : ''} ${skipped ? 'skipped' : ''} ${cur ? 'current' : ''}" data-jump="${i}"></div>`;
-        }).join('')}
-      </div>
+      <div class="dots">${dots}</div>
     </div>
-
-    ${a.exercises.map((e, i) => exerciseCardHtml(e, i, currentExIdx)).join('')}
-
+    <div class="card">
+      <div class="ex-rail">${steps}</div>
+    </div>
     <div class="workout-bottom">
       <div class="workout-bottom-inner">
-        <div class="row between" style="align-items:center; gap:12px;">
-          <span class="subtle" style="white-space:nowrap;">${doneCount} of ${totalEx} complete</span>
-          <button class="btn ${allDone ? 'success' : ''}" id="finish-workout" style="flex:1; max-width:200px;">${allDone ? 'Finish Workout ✓' : 'Finish'}</button>
-        </div>
+        <button class="btn ${allDone ? 'success' : ''}" id="finish-workout">${allDone ? 'Finish Workout ✓' : 'Finish Workout'}</button>
       </div>
     </div>
   `;
 };
 
-function exerciseCardHtml(ex, i, currentExIdx) {
+function exerciseRailStepHtml(ex, i, currentExIdx) {
   const complete = exerciseIsComplete(ex);
   const skipped = !!ex.skipped;
   const done = complete || skipped;
-  const pending = !done && i !== currentExIdx;
-  const isCurrent = i === currentExIdx;
-
-  let cardClass = 'ex-card';
-  if (complete) cardClass += ' done';
-  if (skipped) cardClass += ' skipped';
-  if (pending) cardClass += ' pending';
+  const isCurrent = !done && i === currentExIdx;
+  const name = esc(ex.name);
 
   if (done) {
+    const cls = ['ex-rail-step', skipped ? 'skipped' : 'completed', 'dense-collapsed'].join(' ');
+    const circle = skipped ? '–' : '✓';
+    const badge = skipped
+      ? `<span class="badge warn">${ex.sets.length ? 'Skipped rest' : 'Skipped'}</span>`
+      : `<span class="badge success">${ex.sets.length}/${ex.targetSets} ✓</span>`;
     const summary = skipped
-      ? (ex.sets.length ? `${sessionExerciseSetSummary(ex)} · skipped rest` : 'Skipped')
+      ? (ex.sets.length ? `${esc(sessionExerciseSetSummary(ex))} · skipped rest` : 'Skipped this session')
       : ex.sets.map(s => `${fmtNum(s.weight)}×${s.reps}`).join(' · ');
     return `
-      <div class="${cardClass}" data-ex-idx="${i}">
-        <div class="ex-header">
-          <div class="name">${esc(ex.name)}</div>
-          <div class="progress mono">${skipped ? 'Skipped' : `${ex.sets.length}/${ex.targetSets}`}</div>
-          <div class="check">${skipped ? '–' : '✓'}</div>
+      <div class="${cls}" data-ex-idx="${i}">
+        <div class="ex-rail-node"><span class="ex-rail-circle">${circle}</span></div>
+        <div class="ex-rail-body">
+          <div class="dense-line">
+            <div class="ex-rail-name">${name}</div>
+            ${badge}
+          </div>
+          <div class="dense-summary">${summary}</div>
         </div>
-        <div class="ex-summary">${summary}</div>
       </div>
     `;
   }
 
-  return `
-    <div class="${cardClass}" data-ex-idx="${i}">
-      <div class="ex-header">
-        <div class="name">${esc(ex.name)}</div>
-        <div class="progress mono">${ex.sets.length}/${ex.targetSets}</div>
-        ${isCurrent ? `<button class="btn ghost small skip-ex-btn" data-act="skip-ex" data-ex-idx="${i}">${ex.sets.length ? 'Skip Rest' : 'Skip'}</button>` : ''}
+  if (isCurrent) {
+    const skipLabel = ex.sets.length ? 'Skip Rest' : 'Skip';
+    return `
+      <div class="ex-rail-step active" data-ex-idx="${i}">
+        <div class="ex-rail-node"><span class="ex-rail-circle">${i + 1}</span></div>
+        <div class="ex-rail-body">
+          <div class="dense-line">
+            <div style="min-width:0;">
+              <div class="rail-eyebrow active">In progress</div>
+              <div class="ex-rail-name" style="font-size:17px;">${name}</div>
+            </div>
+            <div class="row" style="gap:6px;">
+              <span class="badge">${ex.sets.length}/${ex.targetSets}</span>
+              <button class="btn ghost small skip-ex-btn" data-act="skip-ex" data-ex-idx="${i}">${skipLabel}</button>
+            </div>
+          </div>
+          <div class="ex-rail-meta" style="margin:2px 0 0;">Target ${ex.targetSets} × ${ex.targetReps}</div>
+          <div class="sets-modern">
+            ${Array.from({length: ex.targetSets}, (_, si) => setRowHtml(ex, i, si, true)).join('')}
+          </div>
+        </div>
       </div>
-      <div class="ex-target">Target: ${ex.targetSets} × ${ex.targetReps}</div>
-      <div class="sets">
-        ${Array.from({length: ex.targetSets}, (_, si) => setRowHtml(ex, i, si, isCurrent)).join('')}
+    `;
+  }
+
+  // Pending — collapsed
+  return `
+    <div class="ex-rail-step upcoming dense-collapsed" data-ex-idx="${i}">
+      <div class="ex-rail-node"><span class="ex-rail-circle">${i + 1}</span></div>
+      <div class="ex-rail-body">
+        <div class="dense-line">
+          <div class="ex-rail-name">${name}</div>
+          <span class="badge muted">${ex.targetSets} × ${ex.targetReps}</span>
+        </div>
       </div>
     </div>
   `;
@@ -101,10 +123,10 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
   if (logged) {
     return `
       <div class="set-row logged" data-edit-set="${exIdx},${si}">
-        <span class="lbl">${si + 1} ✓</span>
+        <span class="lbl">${si + 1}</span>
         <span class="val">${fmtNum(logged.weight)} kg</span>
         <span class="val">× ${logged.reps}</span>
-        <span class="edit-set-btn" aria-hidden="true">✎</span>
+        <span class="set-check" aria-hidden="true">✓</span>
       </div>
     `;
   }
@@ -131,11 +153,7 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
       <input type="tel" inputmode="decimal" class="set-w" value="${wHasValue ? wPrefill : ''}" placeholder="kg" autocomplete="off" maxlength="6">
       ${repsStepperHtml(rPrefill)}
       <button class="log-btn"${wHasValue ? '' : ' disabled'}>✓</button>
-      ${last ? `
-        <div class="last-ref">
-          <span class="last-chip static">Last: ${fmtNum(last.weight)} kg × ${last.reps}</span>
-        </div>
-      ` : ''}
+      ${last ? `<div class="last-chip static">Last: ${fmtNum(last.weight)} kg × ${last.reps}</div>` : ''}
     </div>
   `;
 }
@@ -150,4 +168,3 @@ function repsStepperHtml(value) {
     </div>
   `;
 }
-

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -83,8 +83,8 @@ function skipExercise(exIdx) {
     save();
     render();
     requestAnimationFrame(() => {
-      const nextCard = document.querySelector('.ex-card:not(.done):not(.skipped):not(.pending)');
-      if (nextCard) nextCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const nextStep = document.querySelector('.ex-rail-step.active');
+      if (nextStep) nextStep.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
   };
 
@@ -167,7 +167,8 @@ function logCurrentSet(row) {
   const w = parseFloat(row.querySelector('.set-w').value);
   const r = parseInt(row.querySelector('.set-r').value, 10);
   if (isNaN(w) || isNaN(r) || r <= 0) return;
-  const card = row.closest('.ex-card');
+  const card = row.closest('[data-ex-idx]');
+  if (!card) return;
   const exIdx = +card.dataset.exIdx;
   const ex = state.active.exercises[exIdx];
   ex.sets.push({ weight: w, reps: r, ts: Date.now() });
@@ -183,8 +184,8 @@ function logCurrentSet(row) {
       const stillSameEx = ex.sets.length < ex.targetSets;
       if (stillSameEx) next.focus();
       else {
-        const nextCard = document.querySelector('.ex-card:not(.done):not(.pending)');
-        if (nextCard) nextCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        const nextStep = document.querySelector('.ex-rail-step.active');
+        if (nextStep) nextStep.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }
     }
   });

--- a/styles.css
+++ b/styles.css
@@ -230,202 +230,188 @@
   .dot.done { background: var(--success); }
   .dot.skipped { background: var(--warn); }
 
-  /* Exercise card */
-  .ex-card {
-    background: var(--card);
-    border-radius: var(--radius);
-    margin-bottom: 10px;
-    box-shadow: var(--shadow);
-    overflow: hidden;
-    transition: opacity 0.15s;
+  /* ════════════════════════════════════════════════════════════
+     Inline-Dense workout: vertical exercise rail + modern soft-row
+     set logger. Done and skipped exercises collapse to a single
+     line; the current exercise expands as the focus.
+     ════════════════════════════════════════════════════════════ */
+
+  /* Bold workout day title with WEEK eyebrow */
+  .workout-day-title {
+    font-size: 30px; font-weight: 700; line-height: 1.05;
+    letter-spacing: -0.02em; margin: 0; color: var(--text);
   }
-  .ex-card.pending { opacity: 0.55; }
-  .ex-card.done .ex-header { background: var(--success-dim); }
-  .ex-card.skipped .ex-header { background: #fff4e5; }
-  .ex-card.skipped .check { background: var(--warn); }
-  .ex-header {
-    padding: 14px 16px;
-    display: flex;
-    align-items: center;
-    gap: 10px;
+
+  /* Exercise rail */
+  .ex-rail { margin-top: 4px; }
+  .ex-rail-step {
+    display: grid; grid-template-columns: 32px 1fr; gap: 12px; position: relative;
   }
-  .ex-header .name { flex: 1; font-weight: 600; font-size: 16px; }
-  .ex-header .progress {
-    font-size: 13px;
-    color: var(--text-dim);
-    font-variant-numeric: tabular-nums;
+  .ex-rail-step:not(:last-child) .ex-rail-node::after {
+    content: ""; position: absolute; top: 32px; bottom: -10px; left: 15px;
+    width: 2px; background: var(--border);
   }
-  .ex-header .check {
-    width: 22px; height: 22px;
-    border-radius: 50%;
-    background: var(--success);
-    color: white;
-    display: flex; align-items: center; justify-content: center;
-    font-size: 14px;
-    font-weight: 700;
+  .ex-rail-step.completed:not(:last-child) .ex-rail-node::after { background: var(--success); }
+  .ex-rail-step.skipped:not(:last-child) .ex-rail-node::after { background: var(--warn); }
+  .ex-rail-node { position: relative; display: flex; justify-content: center; padding-top: 0; }
+  .ex-rail-circle {
+    position: relative; z-index: 1; width: 32px; height: 32px; border-radius: 50%;
+    border: 2px solid var(--border); background: var(--card); color: var(--text-dim);
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; flex-shrink: 0;
   }
-  .ex-target { font-size: 13px; color: var(--text-dim); padding: 0 16px 12px; }
-  .ex-summary { font-size: 13px; color: var(--text-dim); padding: 0 16px 12px; font-variant-numeric: tabular-nums; }
+  .ex-rail-step.completed .ex-rail-circle { background: var(--success); border-color: var(--success); color: white; }
+  .ex-rail-step.active .ex-rail-circle { background: var(--accent); border-color: var(--accent); color: white; box-shadow: 0 0 0 5px var(--accent-dim); animation: wt-pulse-accent 2.6s ease-in-out infinite; }
+  .ex-rail-step.skipped .ex-rail-circle { background: var(--warn); border-color: var(--warn); color: white; }
+  .ex-rail-body { min-width: 0; padding-bottom: 18px; }
+  .ex-rail-step:last-child .ex-rail-body { padding-bottom: 0; }
+  .ex-rail-name { font-size: 15px; font-weight: 600; line-height: 1.25; }
+  .ex-rail-step.upcoming .ex-rail-name { color: var(--text-dim); }
+  .ex-rail-meta { color: var(--text-dim); font-size: 13px; margin-top: 2px; font-variant-numeric: tabular-nums; }
+
+  /* Tight collapsed rows in the rail */
+  .dense-collapsed { padding-bottom: 12px; }
+  .dense-collapsed .ex-rail-name { font-size: 15px; }
+  .dense-line {
+    display: flex; align-items: center; justify-content: space-between; gap: 10px; min-width: 0;
+  }
+  .dense-summary {
+    color: var(--text-dim); font-size: 12.5px; margin-top: 2px; font-variant-numeric: tabular-nums;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .dense-collapsed.completed .dense-summary { color: var(--success); }
+  .dense-collapsed.skipped .dense-summary { color: var(--warn); }
+  .ex-rail-step.dense-collapsed .dense-line { min-height: 32px; }
+  .rail-eyebrow { color: var(--text-dim); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+  .rail-eyebrow.active { color: var(--accent); }
   .skip-ex-btn { flex-shrink: 0; }
 
-  /* Set rows */
-  .sets { padding: 0 12px 12px; }
+  /* Active node pulse */
+  @keyframes wt-pulse-accent { 0%, 100% { box-shadow: 0 0 0 5px var(--accent-dim); } 50% { box-shadow: 0 0 0 8px var(--accent-dim); } }
+
+  /* Modern soft-row set logger */
+  .sets, .sets-modern {
+    display: flex; flex-direction: column; gap: 6px;
+    margin-top: 9px; padding: 0;
+  }
   .set-row {
     display: grid;
-    grid-template-columns: 48px 1fr 1fr 56px;
-    gap: 8px;
+    grid-template-columns: 26px 1fr 1fr 44px;
+    gap: 9px;
     align-items: center;
-    padding: 10px 4px;
-    border-top: 1px solid var(--border);
-  }
-  .set-row:first-child { border-top: none; }
-  .set-row .lbl { font-size: 13px; color: var(--text-dim); font-weight: 600; }
-  .set-row.logged {
-    color: var(--text);
-  }
-  .set-row.logged .val {
-    font-size: 16px;
-    font-weight: 500;
-    font-variant-numeric: tabular-nums;
-  }
-  .set-row.logged .lbl { color: var(--success); }
-  .set-row.pending { color: var(--text-faint); }
-  .set-row.pending .val {
-    font-size: 14px;
-    color: var(--text-faint);
-    font-variant-numeric: tabular-nums;
-  }
-  .set-row.active input,
-  .set-row.editing input {
-    height: 44px;
-    padding: 0 12px;
-    text-align: center;
-    font-size: 17px;
-    font-weight: 600;
-    font-variant-numeric: tabular-nums;
     background: var(--bg);
-    border: 1px solid transparent;
-    border-radius: var(--radius-sm);
+    border-radius: 11px;
+    padding: 8px 11px;
+    border: 0;
     box-sizing: border-box;
   }
-  .set-row.active .log-btn {
-    background: var(--accent);
-    color: white;
-    border: none;
-    border-radius: var(--radius-sm);
-    height: 44px;
-    font-size: 20px;
-    cursor: pointer;
-    font-weight: 700;
-    box-sizing: border-box;
+  .set-row .lbl {
+    width: 22px; height: 22px; border-radius: 50%;
+    background: var(--card); color: var(--text-dim);
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 12px; font-weight: 700; font-variant-numeric: tabular-nums;
   }
-  .set-row.active .log-btn:disabled {
-    background: var(--border);
-    color: var(--text-faint);
-  }
+  .set-row .val { font-size: 15px; font-weight: 600; font-variant-numeric: tabular-nums; }
   .set-row.logged {
+    background: var(--success-dim);
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
-    transition: background 0.12s ease;
-    border-radius: var(--radius-sm);
+    transition: filter 0.12s ease;
   }
-  .set-row.logged:active { background: var(--bg); }
-  .edit-set-btn {
-    color: var(--text-faint);
-    font-size: 18px;
+  .set-row.logged:active { filter: brightness(0.96); }
+  .set-row.logged .lbl { background: var(--success); color: white; }
+  .set-row.logged .val { color: var(--text); }
+  .set-row.pending { opacity: 0.7; }
+  .set-row.pending .val { color: var(--text-faint); font-weight: 500; }
+  .set-row .set-check {
     justify-self: end;
+    width: 24px; height: 24px; border-radius: 50%;
+    background: var(--success); color: white;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 700;
+  }
+  .edit-set-btn {
+    justify-self: end;
+    color: var(--text-faint); font-size: 16px;
     pointer-events: none;
   }
+  .set-row.active { background: var(--accent-dim); padding: 7px 8px; }
+  .set-row.active .lbl { background: var(--accent); color: white; }
   .set-row.editing {
-    grid-template-columns: 48px 1fr 1fr 96px;
-    background: var(--accent-dim);
-    border-radius: var(--radius-sm);
-    padding: 8px;
+    background: var(--accent-dim); padding: 7px 8px;
+    grid-template-columns: 26px 1fr 1fr 88px;
   }
-  .set-row.editing .edit-actions {
-    display: flex;
-    gap: 4px;
-  }
-  .set-row.editing .edit-actions .log-btn,
-  .set-row.editing .edit-actions .cancel-btn {
-    flex: 1;
-    border: none;
-    border-radius: var(--radius-sm);
-    height: 44px;
-    font-size: 20px;
+  .set-row.editing .lbl { background: var(--accent); color: white; }
+
+  /* Active / editing weight input */
+  .set-row.active .set-w,
+  .set-row.editing .set-w {
+    height: 40px;
+    background: var(--card);
+    border: 1.5px solid var(--accent);
+    border-radius: 9px;
+    text-align: center;
+    font-size: 17px;
     font-weight: 700;
-    cursor: pointer;
+    font-variant-numeric: tabular-nums;
+    padding: 0 8px;
+    color: var(--text);
     box-sizing: border-box;
   }
-  .set-row.editing .edit-actions .log-btn {
-    background: var(--accent);
-    color: white;
-  }
-  .set-row.editing .edit-actions .log-btn:disabled {
-    background: var(--border);
-    color: var(--text-faint);
-  }
-  .set-row.editing .edit-actions .cancel-btn {
-    background: white;
-    color: var(--text-dim);
-    border: 1px solid var(--border);
-  }
-  .last-ref {
-    grid-column: 2 / 5;
-    margin-top: -4px;
-    padding-bottom: 8px;
-  }
-  .last-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    background: var(--bg);
-    color: var(--text-dim);
-    font-size: 12px;
-    padding: 5px 10px;
-    border-radius: 12px;
-    border: none;
-    cursor: pointer;
-    font-family: inherit;
-    font-variant-numeric: tabular-nums;
-  }
-  .last-chip.static { cursor: default; }
-  .last-chip .copy { color: var(--accent); font-weight: 600; }
 
-  /* Compact reps stepper in workout set rows */
+  /* Reps stepper inside set rows */
   .set-row .reps-stepper {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 44px;
-    background: var(--bg);
-    border: 1px solid transparent;
-    border-radius: var(--radius-sm);
+    display: flex; align-items: center; justify-content: space-between;
+    height: 40px;
+    background: var(--card);
+    border-radius: 9px;
     padding: 2px;
+    border: 0;
     min-width: 0;
     box-sizing: border-box;
   }
   .set-row .reps-stepper .step-btn {
-    width: 40px; height: 38px;
-    font-size: 20px;
-    color: var(--accent);
-    background: transparent;
-    border: none;
-    border-radius: var(--radius-sm);
-    flex-shrink: 0;
-    cursor: pointer;
+    width: 34px; height: 34px; font-size: 19px;
+    color: var(--accent); background: transparent;
+    border: none; border-radius: 8px;
+    flex-shrink: 0; cursor: pointer;
   }
   .set-row .reps-stepper .step-btn:active { background: var(--accent-dim); }
   .set-row .reps-stepper .step-val {
-    flex: 1;
-    text-align: center;
-    font-size: 17px;
-    font-weight: 600;
-    font-variant-numeric: tabular-nums;
-    min-width: 24px;
+    flex: 1; text-align: center;
+    font-size: 16px; font-weight: 700;
+    font-variant-numeric: tabular-nums; min-width: 24px;
   }
-  .set-row.editing .reps-stepper {
-    background: white;
+
+  /* Save / cancel buttons in active and editing rows */
+  .set-row.active .log-btn {
+    height: 40px;
+    background: var(--accent); color: white;
+    border: 0; border-radius: 9px;
+    font-size: 19px; font-weight: 700;
+    cursor: pointer; box-sizing: border-box;
+  }
+  .set-row.active .log-btn:disabled { background: var(--border); color: var(--text-faint); }
+  .set-row.editing .edit-actions { display: flex; gap: 4px; }
+  .set-row.editing .edit-actions .log-btn,
+  .set-row.editing .edit-actions .cancel-btn {
+    flex: 1; height: 40px; border: 0; border-radius: 9px;
+    font-size: 19px; font-weight: 700; cursor: pointer; box-sizing: border-box;
+  }
+  .set-row.editing .edit-actions .log-btn { background: var(--accent); color: white; }
+  .set-row.editing .edit-actions .log-btn:disabled { background: var(--border); color: var(--text-faint); }
+  .set-row.editing .edit-actions .cancel-btn { background: var(--card); color: var(--text-dim); border: 1px solid var(--border); }
+
+  /* "Last time" reference below the active row */
+  .last-chip,
+  .last-chip.static {
+    display: block;
+    grid-column: 1 / -1;
+    background: transparent; color: var(--text-dim);
+    font-size: 12px; padding: 4px 4px 0;
+    border: 0; border-radius: 0;
+    font-family: inherit; cursor: default;
+    font-variant-numeric: tabular-nums;
   }
 
   /* Bottom bar in workout */


### PR DESCRIPTION
## Summary

Rebased onto the new modular master (`js/views/*.js` + `styles.css`). Master already shipped the Inline Dense **Today** treatment (week-stepper + vertical day-step rail) via PR #22/#23, so this PR now applies the remaining design pieces only to the **Workout** flow.

## Workout view

- Stacked `.ex-card` layout → **vertical exercise rail** (numbered circles on a connector line), matching the week-stepper vocabulary master already uses on Today.
- **Done** exercises collapse to one tight line: name, `X/Y ✓` badge, and a summary of logged sets (`60×8 · 60×8 · 60×8`).
- **Skipped** exercises collapse the same way with the orange warn badge and orange node — preserves master's skip-rest feature.
- **Current** exercise expands as the focus: `In progress` eyebrow, larger name, `X/Y` badge alongside the Skip / Skip-Rest button, target line, and the modern set logger inline.
- **Pending** exercises stay tight with just the name and a muted target pill (`4 × 8`).
- Header: small `Week N · Day` subtitle → bold **`workout-day-title`** with a small `WEEK N` eyebrow above it (mirrors the bold Today header treatment).
- Bottom bar: drops the `X of Y complete` subtitle (the dots row already carries that) — Finish button gets the full width.

## Modern set logger

Ruled grid → soft rounded rows:
- **Logged**: green-tinted bg, green number badge, `60 kg × 8`, green check on the right.
- **Active**: blue-tinted bg, blue number badge, white-card weight field on a blue border, reps stepper, log button — all at a consistent 40 px height.
- **Pending**: muted gray, `– kg × –`.
- **Editing**: blue tint, save/cancel pair on the right.
- **"Last: 60 kg × 8"** moves below the row as a single faint line spanning all four columns.
- Whole logged row still tappable to enter inline edit.

## Plumbing

- `logCurrentSet` now finds the exercise container via `closest('[data-ex-idx]')` (the `.ex-card` class is gone).
- The two next-step auto-scroll calls look up `.ex-rail-step.active` instead of `.ex-card`.
- Removes the `.ex-card`, `.ex-header`, `.ex-target`, `.ex-summary`, `.sets` CSS that no markup references anymore.

Version stamp: **v20 · inline dense**.

## Conflict resolution

The original PR was authored against the monolithic `weight-tracker/index.html`. While it was open, master modularised everything into `/js/*` + `/styles.css` and shipped an Inline-Dense Today (PR #21/#22/#23). I:

1. Reset the branch to `origin/master` (adopting the new structure).
2. Re-applied only the design pieces still missing from master — the Workout view and the modern set logger.
3. Preserved master's `data-act="skip-ex"` skip-rest feature in the new rail layout.

This is now a single focused commit on top of master with no conflicts.

## Test plan

- [ ] Merge, wait for Pages deploy, reload. Version stamp reads `v20 · inline dense`.
- [ ] Start a workout. The header shows `WEEK N` eyebrow + bold day title; below it the dots row.
- [ ] Below the dots, the exercise rail: numbered circles with a connector line.
- [ ] Log a set on the current exercise → green soft-row appears with green number badge + check on the right.
- [ ] Finish the current exercise → it collapses to one line; the next exercise's rail step becomes active (blue, pulsing) with the modern set logger.
- [ ] Tap **Skip** on the current exercise → the row collapses with an orange node and "Skipped" badge; the next exercise becomes active.
- [ ] Tap a logged set → flips into inline edit (stepper + inputs); ✓ saves, × cancels.
- [ ] Bottom bar shows a single full-width **Finish Workout** button.
