### PR TITLE
Add versioned service worker + auto-reload on update

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -13,6 +13,17 @@ if (!storageWorks()) {
 }
 
 if ('serviceWorker' in navigator) {
+  // Reload exactly once when a new service worker takes over so the
+  // next request stream comes from the fresh deploy. Without this the
+  // page sticks on whatever the old SW handed it until the user
+  // manually refreshes (or closes every tab).
+  let reloaded = false;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (reloaded) return;
+    reloaded = true;
+    location.reload();
+  });
+
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('service-worker.js').catch(() => {});
   });

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* ---------- State ---------- */
-const APP_VERSION = 'v20 · inline dense';
+const APP_VERSION = 'v21 · sw cache fix';
 
 const EXERCISE_LIBRARY = [
   // Squat / quad

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,85 @@
+/* Weight Trainer service worker.
+   Cache name is version-keyed so each deploy invalidates the previous
+   wholesale. Network-first for the HTML / JS / CSS shell so code
+   updates land on the next reload; cache-first for static assets so
+   icons stay fast and offline. skipWaiting + clients.claim plus a
+   controllerchange auto-reload in app.js means a new deploy takes
+   over without users having to close every tab.
+
+   IMPORTANT: bump VERSION on every release so old caches drop. */
+const VERSION = 'v21';
+const CACHE = `wt-${VERSION}`;
+const SHELL = [
+  './',
+  './index.html',
+  './styles.css',
+  './js/constants.js',
+  './js/utils.js',
+  './js/state.js',
+  './js/views.js',
+  './js/programs.js',
+  './js/views/today.js',
+  './js/views/settings.js',
+  './js/views/history.js',
+  './js/views/workout.js',
+  './js/views/celebration.js',
+  './js/workouts.js',
+  './js/events.js',
+  './js/app.js'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE).then((cache) => cache.addAll(SHELL).catch(() => {}))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+function isShellRequest(request) {
+  if (request.mode === 'navigate') return true;
+  const accept = request.headers.get('accept') || '';
+  if (accept.includes('text/html')) return true;
+  const url = new URL(request.url);
+  return url.pathname.endsWith('.js') || url.pathname.endsWith('.css');
+}
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  const req = event.request;
+
+  if (isShellRequest(req)) {
+    // Network-first: bypass the browser HTTP cache so a deploy is
+    // visible on the very next request. Fall back to the SW cache
+    // only when offline.
+    event.respondWith(
+      fetch(req, { cache: 'reload' })
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE).then((cache) => cache.put(req, copy)).catch(() => {});
+          return response;
+        })
+        .catch(() => caches.match(req).then((c) => c || caches.match('./index.html') || caches.match('./')))
+    );
+    return;
+  }
+
+  // Cache-first for static assets (icons, manifest, etc.)
+  event.respondWith(
+    caches.match(req).then((cached) => {
+      if (cached) return cached;
+      return fetch(req).then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE).then((cache) => cache.put(req, copy)).catch(() => {});
+        return response;
+      }).catch(() => cached);
+    })
+  );
+});


### PR DESCRIPTION
## Summary

Fixes the "regular browser shows old version, incognito shows new" problem you hit. Two issues bundled:

1. **Service worker is missing from the repo.** `js/app.js` tries to `register('service-worker.js')` but the file was dropped during the modular restructure — the catch silently swallows the 404. Browsers that had registered the **old SW** (from when the app lived at `weight-tracker/service-worker.js`) keep that worker active and keep serving cached content. Incognito works because incognito starts with no SW registered.
2. **No update flow.** Even with a SW, the page sticks on whatever the old SW served until every tab is closed or the user manually clears site data.

## What this PR does

### `service-worker.js` (new, at repo root)

- **Cache name is version-keyed** (`wt-v21`). Each deploy that bumps `VERSION` invalidates the previous cache wholesale — the `activate` handler iterates `caches.keys()` and deletes anything that isn't the current name.
- **Network-first for the HTML / JS / CSS shell** with `fetch(req, { cache: 'reload' })` so the browser HTTP layer also has to revalidate. A code change is visible on the very next request — no "clear site data" dance.
- **Cache-first for static assets** (icons, manifest) so they stay fast and offline.
- **`skipWaiting()` in install + `clients.claim()` in activate**, so the new SW takes over immediately without waiting for every tab to close.

### `js/app.js`

Adds a `controllerchange` listener that auto-reloads the page exactly once when a new SW takes over. Combined with skip-waiting + claim, the deploy flow is:

> deploy lands → user opens app → new SW installs and activates → `controllerchange` fires → page reloads → fresh content shown.

No manual refresh, no incognito.

## Reminder for future releases

Bump `VERSION` in `service-worker.js` alongside `APP_VERSION` in `js/constants.js` so the cache name changes. I bumped both to `v21` for this release.

## Test plan

- [ ] Merge, wait for Pages deploy.
- [ ] In a **regular browser tab** (not incognito) that's been showing the old version, hard-reload once. The SW should register; on the *next* normal reload (or app re-open) it should auto-refresh to `v21 · sw cache fix`.
- [ ] In Chrome DevTools → Application → Service Workers, confirm only `wt-v21` cache exists (no older `wt-vN` caches lingering).
- [ ] Push a small test commit and bump `VERSION` to `v22`. After deploy, open the app: new SW installs, page should auto-reload to v22 without manual action.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BW3wN8yik1X8Fpc4pkUZ7M)_