### PR TITLE
Add rest timer, tappable Last chip, and in-place set logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 <script src="js/views/history.js"></script>
 <script src="js/views/workout.js"></script>
 <script src="js/views/celebration.js"></script>
+<script src="js/rest-timer.js"></script>
 <script src="js/workouts.js"></script>
 <script src="js/events.js"></script>
 <script src="js/app.js"></script>

--- a/js/events.js
+++ b/js/events.js
@@ -20,6 +20,32 @@ function onClick(e) {
     return;
   }
 
+  // Rest timer controls
+  const restBtn = e.target.closest('[data-rest]');
+  if (restBtn) {
+    const v = restBtn.dataset.rest;
+    if (v === 'skip') stopRest();
+    else adjustRest(parseInt(v, 10));
+    return;
+  }
+
+  // "Last time" chip — fill the active set with the previous values
+  const fillBtn = e.target.closest('[data-fill-last]');
+  if (fillBtn) {
+    const row = fillBtn.closest('.set-row.active');
+    if (row) {
+      const wInput = row.querySelector('.set-w');
+      const rHidden = row.querySelector('.set-r');
+      const rDisplay = row.querySelector('.reps-stepper .step-val');
+      if (wInput) wInput.value = fillBtn.dataset.w;
+      if (rHidden) rHidden.value = fillBtn.dataset.r;
+      if (rDisplay) rDisplay.textContent = fillBtn.dataset.r;
+      row.dataset.dirty = '1';
+      updateLogBtn(row);
+    }
+    return;
+  }
+
   // Setup screen
   if (e.target.classList.contains('step-btn')) {
     if (e.target.closest('.set-row')) {

--- a/js/rest-timer.js
+++ b/js/rest-timer.js
@@ -1,0 +1,92 @@
+/* ---------- Rest timer ----------
+   Self-contained countdown shown between sets during a workout.
+   Managed via direct DOM (appended to <body>) so it survives the
+   view re-renders triggered by logging/finishing. */
+
+const REST_KEY = 'wt-rest-default';
+let restState = { remaining: 0, total: 0, intervalId: null, done: false };
+
+function restDefaultSeconds() {
+  const v = parseInt(localStorage.getItem(REST_KEY), 10);
+  return (!isNaN(v) && v >= 15) ? v : 120;
+}
+
+function setRestDefault(sec) {
+  const clamped = Math.max(15, Math.min(600, sec));
+  try { localStorage.setItem(REST_KEY, String(clamped)); } catch (_) {}
+}
+
+function startRest(seconds) {
+  const total = seconds || restDefaultSeconds();
+  restState.total = total;
+  restState.remaining = total;
+  restState.done = false;
+  if (restState.intervalId) clearInterval(restState.intervalId);
+  restState.intervalId = setInterval(restTick, 1000);
+  renderRestBar();
+}
+
+function restTick() {
+  restState.remaining -= 1;
+  if (restState.remaining <= 0) {
+    restState.remaining = 0;
+    restState.done = true;
+    clearInterval(restState.intervalId);
+    restState.intervalId = null;
+    buzz([60, 80, 60]);
+  }
+  renderRestBar();
+}
+
+function adjustRest(delta) {
+  if (!restBarVisible()) return;
+  restState.remaining = Math.max(0, restState.remaining + delta);
+  restState.total = Math.max(restState.total, restState.remaining, 1);
+  if (restState.remaining > 0) {
+    restState.done = false;
+    if (!restState.intervalId) restState.intervalId = setInterval(restTick, 1000);
+    // Remember the user's adjusted length as the new default.
+    setRestDefault(restState.remaining);
+  }
+  renderRestBar();
+}
+
+function stopRest() {
+  if (restState.intervalId) clearInterval(restState.intervalId);
+  restState = { remaining: 0, total: 0, intervalId: null, done: false };
+  removeRestBar();
+}
+
+function restBarVisible() {
+  return !!document.getElementById('rest-bar');
+}
+
+function removeRestBar() {
+  const bar = document.getElementById('rest-bar');
+  if (bar) bar.remove();
+}
+
+function renderRestBar() {
+  let bar = document.getElementById('rest-bar');
+  if (!bar) {
+    bar = document.createElement('div');
+    bar.id = 'rest-bar';
+    document.body.appendChild(bar);
+  }
+  const pct = restState.total ? Math.max(0, restState.remaining / restState.total) * 100 : 0;
+  const mm = Math.floor(restState.remaining / 60);
+  const ss = String(restState.remaining % 60).padStart(2, '0');
+  bar.className = restState.done ? 'rest-bar done' : 'rest-bar';
+  bar.innerHTML = `
+    <div class="rest-fill" style="width:${pct}%"></div>
+    <div class="rest-inner">
+      <button class="rest-btn" data-rest="-15" type="button" aria-label="Subtract 15 seconds">−15</button>
+      <div class="rest-mid">
+        <span class="rest-label">${restState.done ? 'Rest done' : 'Rest'}</span>
+        <span class="rest-time">${mm}:${ss}</span>
+      </div>
+      <button class="rest-btn" data-rest="15" type="button" aria-label="Add 15 seconds">+15</button>
+      <button class="rest-btn skip" data-rest="skip" type="button">${restState.done ? 'Done' : 'Skip'}</button>
+    </div>
+  `;
+}

--- a/js/views.js
+++ b/js/views.js
@@ -15,6 +15,8 @@ function render() {
     body += `<div class="version-stamp">${APP_VERSION}</div>`;
   }
   app.innerHTML = body;
+  // The rest timer only belongs to an active workout; clear it elsewhere.
+  if (view !== 'workout' && typeof stopRest === 'function') stopRest();
   app.classList.toggle('fullscreen', view === 'workout');
   const showTabs = view === 'today' || view === 'program' || view === 'history';
   tabs.hidden = !showTabs;

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -153,7 +153,7 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
       <input type="tel" inputmode="decimal" class="set-w" value="${wHasValue ? wPrefill : ''}" placeholder="kg" autocomplete="off" maxlength="6">
       ${repsStepperHtml(rPrefill)}
       <button class="log-btn"${wHasValue ? '' : ' disabled'}>✓</button>
-      ${last ? `<div class="last-chip static">Last: ${fmtNum(last.weight)} kg × ${last.reps}</div>` : ''}
+      ${last ? `<button type="button" class="last-chip" data-fill-last data-w="${last.weight}" data-r="${last.reps}">Last: ${fmtNum(last.weight)} kg × ${last.reps} · tap to use</button>` : ''}
     </div>
   `;
 }

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -172,22 +172,33 @@ function logCurrentSet(row) {
   const exIdx = +card.dataset.exIdx;
   const ex = state.active.exercises[exIdx];
   ex.sets.push({ weight: w, reps: r, ts: Date.now() });
-  const exJustCompleted = ex.sets.length === ex.targetSets;
-  buzz(exJustCompleted ? [20, 40, 20] : 12);
+  const stillSameEx = ex.sets.length < ex.targetSets;
+  buzz(stillSameEx ? 12 : [20, 40, 20]);
   save();
-  render();
-  // After render, focus the next active input if there is one
-  requestAnimationFrame(() => {
-    const next = document.querySelector('.set-row.active .set-w');
-    if (next && document.activeElement !== next) {
-      // Auto-focus only on same-exercise advance, to avoid hijacking when an exercise finishes
-      const stillSameEx = ex.sets.length < ex.targetSets;
-      if (stillSameEx) next.focus();
-      else {
-        const nextStep = document.querySelector('.ex-rail-step.active');
-        if (nextStep) nextStep.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }
+  startRest();
+
+  if (stillSameEx) {
+    // In-place advance: patch only this exercise's set rows + counter so the
+    // input stays responsive and we avoid re-rendering the whole rail.
+    const setsWrap = card.querySelector('.sets-modern');
+    if (setsWrap) {
+      setsWrap.innerHTML = Array.from({ length: ex.targetSets },
+        (_, si) => setRowHtml(ex, exIdx, si, true)).join('');
     }
+    const badge = card.querySelector('.dense-line .badge');
+    if (badge) badge.textContent = `${ex.sets.length}/${ex.targetSets}`;
+    requestAnimationFrame(() => {
+      const next = card.querySelector('.set-row.active .set-w');
+      if (next && document.activeElement !== next) next.focus();
+    });
+    return;
+  }
+
+  // Exercise finished — full render to collapse it and advance the rail.
+  render();
+  requestAnimationFrame(() => {
+    const nextStep = document.querySelector('.ex-rail-step.active');
+    if (nextStep) nextStep.scrollIntoView({ behavior: 'smooth', block: 'start' });
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -402,16 +402,22 @@
   .set-row.editing .edit-actions .log-btn:disabled { background: var(--border); color: var(--text-faint); }
   .set-row.editing .edit-actions .cancel-btn { background: var(--card); color: var(--text-dim); border: 1px solid var(--border); }
 
-  /* "Last time" reference below the active row */
-  .last-chip,
-  .last-chip.static {
-    display: block;
-    grid-column: 1 / -1;
-    background: transparent; color: var(--text-dim);
-    font-size: 12px; padding: 4px 4px 0;
-    border: 0; border-radius: 0;
-    font-family: inherit; cursor: default;
+  /* "Last time" reference below the active row — tap to copy into the set */
+  .last-chip {
+    display: inline-flex; align-items: center;
+    grid-column: 1 / -1; justify-self: start;
+    margin-top: 4px;
+    background: var(--accent-dim); color: var(--accent);
+    font-size: 12px; padding: 5px 10px;
+    border: 0; border-radius: 999px;
+    font-family: inherit; cursor: pointer;
     font-variant-numeric: tabular-nums;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .last-chip:active { transform: scale(0.96); }
+  .last-chip.static {
+    background: transparent; color: var(--text-dim);
+    padding: 4px 4px 0; cursor: default;
   }
 
   /* Bottom bar in workout */
@@ -427,6 +433,55 @@
     z-index: 40;
   }
   .workout-bottom-inner { max-width: 640px; margin: 0 auto; }
+
+  /* Rest timer bar — sits just above the Finish bar */
+  .rest-bar {
+    position: fixed;
+    left: 0; right: 0;
+    bottom: calc(var(--safe-bottom) + 68px);
+    z-index: 39;
+    overflow: hidden;
+    background: var(--card);
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    box-shadow: 0 -4px 16px rgba(0,0,0,0.06);
+  }
+  .rest-fill {
+    position: absolute; inset: 0 auto 0 0;
+    background: var(--accent-dim);
+    transition: width 1s linear;
+    z-index: 0;
+  }
+  .rest-bar.done .rest-fill { background: rgba(52,199,89,0.18); }
+  .rest-inner {
+    position: relative; z-index: 1;
+    max-width: 640px; margin: 0 auto;
+    display: flex; align-items: center; gap: 10px;
+    padding: 8px 16px;
+  }
+  .rest-mid {
+    flex: 1; display: flex; flex-direction: column;
+    align-items: center; line-height: 1.1;
+  }
+  .rest-label {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--text-dim);
+  }
+  .rest-bar.done .rest-label { color: var(--success); }
+  .rest-time {
+    font-size: 20px; font-weight: 600;
+    font-variant-numeric: tabular-nums; color: var(--text);
+  }
+  .rest-btn {
+    border: 1px solid var(--border); background: var(--bg);
+    color: var(--text-dim); font-family: inherit;
+    font-size: 13px; font-weight: 600;
+    padding: 7px 11px; border-radius: 10px; cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .rest-btn:active { transform: scale(0.95); }
+  .rest-btn.skip { color: var(--accent); }
+  .rest-bar.done .rest-btn.skip { background: var(--success); color: #fff; border-color: var(--success); }
 
   /* Setup */
   .day-editor {


### PR DESCRIPTION
Improves the core in-workout logging loop:

- Rest timer (js/rest-timer.js): auto-starts when a set is logged. Sticky bar above the Finish button with a draining progress fill, m:ss, -15/+15, and Skip. Buzzes at zero. Default 120s, remembered and adjustable. Lives on document.body so it survives view re-renders; cleared when leaving the workout.
- Tappable "Last" chip: the previous-session reference becomes a one-tap button that fills weight + reps into the active set.
- In-place set logging: advancing sets within an exercise now patches only that exercise's set rows + counter instead of re-rendering the whole rail, removing flicker and the focus/scroll-restore hack. Exercise-boundary transitions still full-render.