### PR TITLE
Move active workout into its own Workout tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 <div id="app"></div>
 <nav id="tabs" hidden>
   <button class="tab" data-tab="today"><span class="ico">⌂</span><span>Today</span></button>
+  <button class="tab" data-tab="workout"><span class="ico">💪</span><span>Workout</span></button>
   <button class="tab" data-tab="program"><span class="ico">⚙</span><span>Settings</span></button>
   <button class="tab" data-tab="history"><span class="ico">◷</span><span>History</span></button>
 </nav>

--- a/js/events.js
+++ b/js/events.js
@@ -261,6 +261,8 @@ function onClick(e) {
         : dayKey(selectedWeekIndex, c.dayIndex);
     }
     state.celebration = null;
+    // The session is over — return to Today rather than the empty Workout tab.
+    state.tab = 'today';
     save();
     render();
     return;

--- a/js/views.js
+++ b/js/views.js
@@ -2,7 +2,8 @@
 function pickView() {
   if (state.celebration) return 'celebration';
   if (!state.program || state.editing) return 'setup';
-  if (state.active) return 'workout';
+  // The active workout now lives in its own tab, so honour state.tab and let
+  // the user freely navigate in and out of the workout while a session runs.
   return state.tab;
 }
 
@@ -15,13 +16,17 @@ function render() {
     body += `<div class="version-stamp">${APP_VERSION}</div>`;
   }
   app.innerHTML = body;
-  // The rest timer only belongs to an active workout; clear it elsewhere.
-  if (view !== 'workout' && typeof stopRest === 'function') stopRest();
-  app.classList.toggle('fullscreen', view === 'workout');
-  const showTabs = view === 'today' || view === 'program' || view === 'history';
+  // The rest timer belongs to the active session, not a specific tab — keep it
+  // running while you navigate, and clear it only when the session ends.
+  if (!state.active && typeof stopRest === 'function') stopRest();
+  // Extra bottom padding only when the workout log (with its Finish bar) is shown.
+  app.classList.toggle('workout-mode', view === 'workout' && !!state.active);
+  const showTabs = view === 'today' || view === 'workout' || view === 'program' || view === 'history';
   tabs.hidden = !showTabs;
   if (showTabs) {
     $$('.tab', tabs).forEach(t => t.classList.toggle('active', t.dataset.tab === state.tab));
+    const wt = tabs.querySelector('[data-tab="workout"]');
+    if (wt) wt.classList.toggle('has-session', !!state.active);
   }
   if (modal) renderModal();
   // Scroll to top on view change (but not for active workout re-renders)

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -1,5 +1,6 @@
 Views.workout = function() {
   const a = state.active;
+  if (!a) return workoutEmptyHtml();
   const currentExIdx = a.exercises.findIndex(e => !exerciseIsResolved(e));
   const allDone = currentExIdx === -1;
 
@@ -30,6 +31,24 @@ Views.workout = function() {
     </div>
   `;
 };
+
+function workoutEmptyHtml() {
+  const complete = programIsComplete();
+  const next = complete ? -1 : nextDayIndex();
+  const day = (next >= 0 && state.program) ? state.program.template[next] : null;
+  const upNext = day
+    ? `<div class="faint" style="margin-top:8px;">Up next: ${esc(day.name || 'Workout ' + (next + 1))}</div>`
+    : `<div class="faint" style="margin-top:8px;">${complete ? 'Program complete.' : 'Start one from Today.'}</div>`;
+  return `
+    <h1>Workout</h1>
+    <div class="empty">
+      <div class="ico">💪</div>
+      <div>No active workout.</div>
+      ${upNext}
+      <button class="btn" data-tab="today" style="margin-top:18px; max-width:260px;">Go to Today</button>
+    </div>
+  `;
+}
 
 function exerciseRailStepHtml(ex, i, currentExIdx) {
   const complete = exerciseIsComplete(ex);

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -23,6 +23,7 @@ function startWorkout(dayIndex) {
       skipped: false
     }))
   };
+  state.tab = 'workout';
   save();
   render();
 }
@@ -120,7 +121,7 @@ function endWorkoutFlow() {
         state.active = null;
         editingSet = null;
         closeModal();
-        setState({});
+        setState({ tab: 'today' });
       }
     });
     return;
@@ -142,7 +143,7 @@ function endWorkoutFlow() {
         state.active = null;
         editingSet = null;
         closeModal();
-        setState({});
+        setState({ tab: 'today' });
       }
     }
   });

--- a/styles.css
+++ b/styles.css
@@ -35,8 +35,9 @@
     margin: 0 auto;
     padding: calc(16px + var(--safe-top)) 16px calc(var(--tab-h) + var(--safe-bottom) + 16px);
   }
-  #app.fullscreen {
-    padding-bottom: calc(var(--safe-bottom) + 96px);
+  /* Active workout log: clear both the Finish bar and the tab bar below it. */
+  #app.workout-mode {
+    padding-bottom: calc(var(--safe-bottom) + var(--tab-h) + 88px);
   }
 
   /* Typography */
@@ -145,8 +146,23 @@
     padding: 8px 4px;
     font-family: inherit;
   }
-  .tab .ico { font-size: 22px; line-height: 1; }
+  .tab .ico { font-size: 22px; line-height: 1; position: relative; }
   .tab.active { color: var(--accent); }
+  /* Pulsing dot on the Workout tab while a session is in progress */
+  .tab.has-session .ico::after {
+    content: '';
+    position: absolute;
+    top: -1px; right: -7px;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: var(--success);
+    box-shadow: 0 0 0 2px var(--card);
+    animation: session-pulse 1.6s ease-in-out infinite;
+  }
+  @keyframes session-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
+  }
 
   /* Stat row */
   .stats {
@@ -423,7 +439,7 @@
   /* Bottom bar in workout */
   .workout-bottom {
     position: fixed;
-    bottom: var(--safe-bottom);
+    bottom: calc(var(--safe-bottom) + var(--tab-h));
     left: 0; right: 0;
     background: rgba(255,255,255,0.92);
     backdrop-filter: saturate(180%) blur(20px);
@@ -438,7 +454,7 @@
   .rest-bar {
     position: fixed;
     left: 0; right: 0;
-    bottom: calc(var(--safe-bottom) + 68px);
+    bottom: calc(var(--safe-bottom) + var(--tab-h) + 68px);
     z-index: 39;
     overflow: hidden;
     background: var(--card);


### PR DESCRIPTION
Previously the active workout was a full-screen takeover with no way to navigate in or out of it. It now lives in a dedicated Workout tab in the bottom bar, enabling free navigation while a session is in progress.

- Routing: pickView() honours state.tab instead of forcing the workout view whenever a session is active. All tabs are navigable mid-workout; the session persists in state.active independent of the visible tab.
- Nav: added a "Workout" tab (between Today and Settings) with a pulsing green dot on its icon while a session is active.
- Empty state: the Workout tab shows "No active workout" with an up-next hint and a Go to Today button when nothing is running.
- Flow: Start auto-switches to the Workout tab; discard and the celebration Continue both return to Today. Celebration stays a full-screen takeover.
- Rest timer now persists across tabs while a session runs, clearing only when the session ends.
- Layout: the Finish bar and rest bar are lifted above the now always-visible tab bar; renamed the .fullscreen class to .workout-mode.