### PR TITLE
Add prebuilt program templates and a Today choice screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
 <script src="js/programs.js"></script>
 <script src="js/views/today.js"></script>
 <script src="js/views/settings.js"></script>
+<script src="js/views/start.js"></script>
 <script src="js/views/history.js"></script>
 <script src="js/views/workout.js"></script>
 <script src="js/views/celebration.js"></script>

--- a/js/constants.js
+++ b/js/constants.js
@@ -37,6 +37,125 @@ const EXERCISE_LIBRARY = [
   // Olympic / total body
   'Power Clean', 'Clean and Press', 'Snatch', 'Farmer’s Walk', 'Turkish Get-Up'
 ];
+
+/* Prebuilt program templates. Read-only catalog: selecting one clones an
+   editable copy into the user's library, leaving these pristine. */
+const mkEx = (name, sets, reps) => ({ name, sets, reps });
+const PREBUILT_PROGRAMS = [
+  {
+    id: 'prebuilt-beginner-full-body',
+    name: 'Beginner Full Body',
+    description: '3 days/week · full-body basics to build a foundation',
+    weeks: 8,
+    template: [
+      { name: 'Full Body A', exercises: [
+        mkEx('Goblet Squat', 3, 10), mkEx('Dumbbell Bench Press', 3, 10),
+        mkEx('Seated Cable Row', 3, 10), mkEx('Dumbbell Shoulder Press', 3, 10),
+        mkEx('Plank', 3, 30)
+      ]},
+      { name: 'Full Body B', exercises: [
+        mkEx('Leg Press', 3, 12), mkEx('Lat Pulldown', 3, 10),
+        mkEx('Incline Dumbbell Press', 3, 10), mkEx('Romanian Deadlift', 3, 10),
+        mkEx('Sit-Up', 3, 15)
+      ]},
+      { name: 'Full Body C', exercises: [
+        mkEx('Back Squat', 3, 8), mkEx('Bench Press', 3, 8),
+        mkEx('Bent-Over Row', 3, 8), mkEx('Lateral Raise', 3, 12),
+        mkEx('Crunch', 3, 15)
+      ]}
+    ]
+  },
+  {
+    id: 'prebuilt-full-body-3day',
+    name: 'Full Body 3-Day',
+    description: '3 days/week · compound-focused, A/B/C rotation',
+    weeks: 8,
+    template: [
+      { name: 'Full Body A', exercises: [
+        mkEx('Back Squat', 3, 8), mkEx('Bench Press', 3, 8),
+        mkEx('Bent-Over Row', 3, 8), mkEx('Overhead Press', 3, 10),
+        mkEx('Plank', 3, 45)
+      ]},
+      { name: 'Full Body B', exercises: [
+        mkEx('Deadlift', 3, 5), mkEx('Incline Bench Press', 3, 8),
+        mkEx('Lat Pulldown', 3, 10), mkEx('Dumbbell Shoulder Press', 3, 10),
+        mkEx('Hanging Leg Raise', 3, 12)
+      ]},
+      { name: 'Full Body C', exercises: [
+        mkEx('Front Squat', 3, 8), mkEx('Dumbbell Bench Press', 3, 10),
+        mkEx('Seated Cable Row', 3, 10), mkEx('Lateral Raise', 3, 12),
+        mkEx('Cable Crunch', 3, 15)
+      ]}
+    ]
+  },
+  {
+    id: 'prebuilt-upper-lower-4day',
+    name: 'Upper/Lower 4-Day',
+    description: '4 days/week · upper and lower split, two sessions each',
+    weeks: 8,
+    template: [
+      { name: 'Upper A', exercises: [
+        mkEx('Bench Press', 4, 6), mkEx('Bent-Over Row', 4, 6),
+        mkEx('Overhead Press', 3, 8), mkEx('Lat Pulldown', 3, 10),
+        mkEx('Barbell Curl', 3, 10), mkEx('Tricep Pushdown', 3, 12)
+      ]},
+      { name: 'Lower A', exercises: [
+        mkEx('Back Squat', 4, 6), mkEx('Romanian Deadlift', 3, 8),
+        mkEx('Leg Press', 3, 10), mkEx('Leg Curl', 3, 12),
+        mkEx('Standing Calf Raise', 4, 12)
+      ]},
+      { name: 'Upper B', exercises: [
+        mkEx('Incline Bench Press', 4, 8), mkEx('Pull-Up', 4, 8),
+        mkEx('Dumbbell Shoulder Press', 3, 10), mkEx('Seated Cable Row', 3, 10),
+        mkEx('Hammer Curl', 3, 12), mkEx('Skull Crusher', 3, 12)
+      ]},
+      { name: 'Lower B', exercises: [
+        mkEx('Deadlift', 4, 5), mkEx('Front Squat', 3, 8),
+        mkEx('Bulgarian Split Squat', 3, 10), mkEx('Leg Extension', 3, 12),
+        mkEx('Seated Calf Raise', 4, 15)
+      ]}
+    ]
+  },
+  {
+    id: 'prebuilt-ppl-6day',
+    name: 'Push/Pull/Legs 6-Day',
+    description: '6 days/week · high-volume push, pull and legs rotation',
+    weeks: 8,
+    template: [
+      { name: 'Push A', exercises: [
+        mkEx('Bench Press', 4, 6), mkEx('Overhead Press', 3, 8),
+        mkEx('Incline Dumbbell Press', 3, 10), mkEx('Lateral Raise', 3, 15),
+        mkEx('Tricep Pushdown', 3, 12), mkEx('Overhead Tricep Extension', 3, 12)
+      ]},
+      { name: 'Pull A', exercises: [
+        mkEx('Deadlift', 3, 5), mkEx('Pull-Up', 4, 8),
+        mkEx('Bent-Over Row', 4, 8), mkEx('Face Pull', 3, 15),
+        mkEx('Barbell Curl', 3, 10), mkEx('Hammer Curl', 3, 12)
+      ]},
+      { name: 'Legs A', exercises: [
+        mkEx('Back Squat', 4, 6), mkEx('Romanian Deadlift', 3, 8),
+        mkEx('Leg Press', 3, 12), mkEx('Leg Curl', 3, 12),
+        mkEx('Standing Calf Raise', 4, 15)
+      ]},
+      { name: 'Push B', exercises: [
+        mkEx('Incline Bench Press', 4, 8), mkEx('Dumbbell Shoulder Press', 3, 10),
+        mkEx('Cable Fly', 3, 12), mkEx('Cable Lateral Raise', 3, 15),
+        mkEx('Close-Grip Bench Press', 3, 10), mkEx('Tricep Pushdown', 3, 15)
+      ]},
+      { name: 'Pull B', exercises: [
+        mkEx('Pendlay Row', 4, 6), mkEx('Lat Pulldown', 3, 10),
+        mkEx('Chest-Supported Row', 3, 10), mkEx('Rear Delt Fly', 3, 15),
+        mkEx('Preacher Curl', 3, 12), mkEx('Cable Curl', 3, 15)
+      ]},
+      { name: 'Legs B', exercises: [
+        mkEx('Front Squat', 4, 8), mkEx('Bulgarian Split Squat', 3, 10),
+        mkEx('Leg Extension', 3, 15), mkEx('Leg Curl', 3, 15),
+        mkEx('Seated Calf Raise', 4, 20), mkEx('Hanging Leg Raise', 3, 12)
+      ]}
+    ]
+  }
+];
+
 const STORAGE_KEY = 'wt-state-v2';
 let saveErrorShown = false;
 const DEFAULT_STATE = {

--- a/js/events.js
+++ b/js/events.js
@@ -128,6 +128,43 @@ function onClick(e) {
     return;
   }
 
+  // Start (choice) screen
+  if (e.target.id === 'start-create') {
+    setupDraft = { id: null, name: 'My Program', weeks: 8, days: [makeDay()], makeActive: true };
+    state.editing = true;
+    save();
+    render();
+    return;
+  }
+  const toggleTpl = e.target.closest && e.target.closest('[data-act="toggle-template"]');
+  if (toggleTpl) {
+    const row = toggleTpl.closest('[data-template-id]');
+    const id = row && row.dataset.templateId;
+    expandedTemplateId = (expandedTemplateId === id) ? null : id;
+    render();
+    return;
+  }
+  if (e.target.dataset.act === 'use-template') {
+    const id = e.target.dataset.templateId;
+    const tpl = findPrebuiltProgram(id);
+    if (!tpl) return;
+    showModal({
+      title: `Use ${tpl.name}?`,
+      body: 'This adds an editable copy to your library and makes it your active program, starting from Week 1.',
+      confirmText: 'Use Program',
+      onConfirm: () => {
+        if (useTemplateProgram(id)) {
+          expandedTemplateId = null;
+          closeModal();
+          setState({ tab: 'today' });
+        } else {
+          closeModal();
+        }
+      }
+    });
+    return;
+  }
+
   // Program tab
   if (e.target.id === 'add-program') {
     setupDraft = { id: null, name: 'New Program', weeks: 8, days: [makeDay()], makeActive: true };

--- a/js/programs.js
+++ b/js/programs.js
@@ -130,6 +130,28 @@ function setActiveProgram(id, opts = {}) {
   return true;
 }
 
+function prebuiltPrograms() {
+  return Array.isArray(PREBUILT_PROGRAMS) ? PREBUILT_PROGRAMS : [];
+}
+
+function findPrebuiltProgram(id) {
+  return prebuiltPrograms().find(p => p.id === id) || null;
+}
+
+// Clone a prebuilt template into the user's library as a fresh editable
+// program, then make it the active program starting from Week 1.
+function useTemplateProgram(id) {
+  const tpl = findPrebuiltProgram(id);
+  if (!tpl) return false;
+  state.programLibrary = normalizeProgramLibrary(state);
+  const program = { name: tpl.name, weeks: tpl.weeks, template: structuredClone(tpl.template) };
+  const record = makeProgramRecord(program);
+  state.programLibrary.unshift(record);
+  record.template.forEach(d => d.exercises.forEach(e => ensureExerciseInLibrary(e.name)));
+  setActiveProgram(record.id, { resetProgress: true });
+  return true;
+}
+
 function activeExerciseLibrary() {
   state.exerciseLibrary = normalizeExerciseLibrary(state);
   return state.exerciseLibrary

--- a/js/views.js
+++ b/js/views.js
@@ -1,7 +1,10 @@
 /* ---------- Routing ---------- */
 function pickView() {
   if (state.celebration) return 'celebration';
-  if (!state.program || state.editing) return 'setup';
+  if (state.editing) return 'setup';
+  // No active program yet: offer the choice screen (create vs. pick a program)
+  // instead of dropping straight into the editor.
+  if (!state.program) return 'start';
   // The active workout now lives in its own tab, so honour state.tab and let
   // the user freely navigate in and out of the workout while a session runs.
   return state.tab;

--- a/js/views/settings.js
+++ b/js/views/settings.js
@@ -7,6 +7,12 @@ Views.program = function() {
       ${programLibraryHtml()}
     </div>
 
+    <h2>Ready-made programs</h2>
+    <div class="card">
+      <div class="subtle" style="margin-bottom:12px;">Add a copy of a prebuilt program to your library.</div>
+      ${programTemplateListHtml()}
+    </div>
+
     <h2>Exercise Library</h2>
     <div class="card">
       ${exerciseLibraryHtml()}

--- a/js/views/start.js
+++ b/js/views/start.js
@@ -1,0 +1,68 @@
+let expandedTemplateId = null;  // UI-only: which prebuilt template is expanded
+
+Views.start = function() {
+  const saved = activeProgramLibrary();
+  return `
+    <div class="start-screen">
+      <h1>Start training</h1>
+      <p class="subtle">Choose a ready-made program or build your own. You can edit anything later.</p>
+
+      <button class="btn" id="start-create" style="margin-top:18px;">+ Create program from scratch</button>
+
+      ${saved.length ? `
+        <h2>Your programs</h2>
+        <div class="card">
+          <div class="library-list">${saved.map(programLibraryRowHtml).join('')}</div>
+        </div>
+      ` : ''}
+
+      <h2>Ready-made programs</h2>
+      <div class="card">${programTemplateListHtml()}</div>
+    </div>
+  `;
+};
+
+function programTemplateListHtml() {
+  const list = prebuiltPrograms();
+  if (!list.length) return `<div class="empty" style="padding:24px 12px;">No templates available.</div>`;
+  return `<div class="library-list">${list.map(programTemplateRowHtml).join('')}</div>`;
+}
+
+function programTemplateRowHtml(tpl) {
+  const expanded = expandedTemplateId === tpl.id;
+  const dayCount = tpl.template.length;
+  return `
+    <div class="library-row template-row ${expanded ? 'expanded' : ''}" data-template-id="${esc(tpl.id)}">
+      <button class="template-summary" data-act="toggle-template">
+        <div class="library-name">
+          <div>${esc(tpl.name)}</div>
+          <div class="library-meta">${tpl.weeks} weeks &middot; ${dayCount} workout${dayCount === 1 ? '' : 's'} each week</div>
+          ${tpl.description ? `<div class="library-meta">${esc(tpl.description)}</div>` : ''}
+        </div>
+        <span class="chevron" aria-hidden="true">${expanded ? '&#9662;' : '&#9656;'}</span>
+      </button>
+      ${expanded ? templatePreviewHtml(tpl) : ''}
+    </div>
+  `;
+}
+
+function templatePreviewHtml(tpl) {
+  return `
+    <div class="template-preview">
+      ${tpl.template.map(d => `
+        <div class="template-day">
+          <div class="template-day-name">${esc(d.name)}</div>
+          <div class="exercise-preview-list">
+            ${d.exercises.map(e => `
+              <div class="exercise-preview-row">
+                <span class="target">${e.sets}&times;${e.reps}</span>
+                <span>${esc(e.name)}</span>
+              </div>
+            `).join('')}
+          </div>
+        </div>
+      `).join('')}
+      <button class="btn" data-act="use-template" data-template-id="${esc(tpl.id)}" style="margin-top:4px;">Use this program</button>
+    </div>
+  `;
+}

--- a/styles.css
+++ b/styles.css
@@ -961,6 +961,21 @@
   }
   .library-row.editing input { flex: 1; background: white; }
 
+  /* Prebuilt template rows (expandable preview) */
+  .library-row.template-row { flex-direction: column; align-items: stretch; padding: 0; }
+  .template-summary {
+    display: flex; align-items: center; gap: 10px;
+    width: 100%; background: transparent; border: 0;
+    padding: 12px 0; cursor: pointer; font-family: inherit;
+    text-align: left; color: var(--text);
+    -webkit-tap-highlight-color: transparent;
+  }
+  .template-summary .library-name { flex: 1; min-width: 0; font-weight: 500; }
+  .template-summary .library-meta { color: var(--text-dim); font-size: 13px; margin-top: 2px; }
+  .template-preview { padding: 2px 0 14px; }
+  .template-day { margin-bottom: 12px; }
+  .template-day-name { font-weight: 600; font-size: 14px; margin-bottom: 2px; }
+
   .week-pip {
     width: 28px; height: 28px;
     border-radius: 50%;


### PR DESCRIPTION
When the user has no active program, the app previously dropped them straight into the program editor. It now offers a choice screen, and ships a catalog of ready-made programs.

- Templates (constants.js): PREBUILT_PROGRAMS, a read-only catalog of 4 curated, non-branded programs (Beginner Full Body, Full Body 3-Day, Upper/Lower 4-Day, Push/Pull/Legs 6-Day), all 8 weeks, built from exercises already in the library.
- Copy-on-use (programs.js): useTemplateProgram() clones a template into the user's library as a fresh editable program, ensures its exercises exist in the exercise library, and activates it from Week 1. Originals stay pristine.
- Start choice screen (views/start.js, routing in views.js): with no active program, show "Create from scratch", the user's saved programs (if any), and the ready-made programs. Template rows expand inline to preview every workout/exercise, with a "Use this program" button and a confirm step.
- Settings (settings.js): a "Ready-made programs" section so templates can be added any time, not just at first run.
- CSS (styles.css): expandable template-row styling reusing existing library/exercise-preview styles.