### PR TITLE
Allow editing logged sets of completed exercises mid-workout

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -262,6 +262,15 @@ function onClick(e) {
     skipExercise(exIdx);
     return;
   }
+  // Reopen a completed exercise in the rail to edit its logged sets
+  const toggleDone = e.target.closest && e.target.closest('[data-toggle-done]');
+  if (toggleDone) {
+    const idx = +toggleDone.dataset.toggleDone;
+    expandedExIdx = (expandedExIdx === idx) ? null : idx;
+    editingSet = null;
+    render();
+    return;
+  }
   const editEl = e.target.closest && e.target.closest('[data-edit-set]');
   if (editEl) {
     const [exIdx, setIdx] = editEl.dataset.editSet.split(',').map(Number);

--- a/js/state.js
+++ b/js/state.js
@@ -164,6 +164,7 @@ function setState(patch) {
 let state = load();
 let setupDraft = null;  // { name, weeks, days: [...] } while editing in setup screen
 let editingSet = null;  // { exIdx, setIdx } when a logged set is being edited
+let expandedExIdx = null;  // index of a completed exercise expanded for editing in the rail
 let selectedWeekIndex = null; // UI-only selected week on Today
 let expandedDayKey = null;    // UI-only expanded Today day, formatted as "week:day"
 let exerciseLibrarySearch = '';

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -58,23 +58,46 @@ function exerciseRailStepHtml(ex, i, currentExIdx) {
   const name = esc(ex.name);
 
   if (done) {
-    const cls = ['ex-rail-step', skipped ? 'skipped' : 'completed', 'dense-collapsed'].join(' ');
     const circle = skipped ? '–' : '✓';
     const badge = skipped
       ? `<span class="badge warn">${ex.sets.length ? 'Skipped rest' : 'Skipped'}</span>`
       : `<span class="badge success">${ex.sets.length}/${ex.targetSets} ✓</span>`;
+    // Only exercises with logged sets can be reopened to fix a typed value.
+    const editable = ex.sets.length > 0;
+    const expanded = editable && i === expandedExIdx;
+
+    if (expanded) {
+      return `
+        <div class="ex-rail-step ${skipped ? 'skipped' : 'completed'} expanded" data-ex-idx="${i}">
+          <div class="ex-rail-node"><span class="ex-rail-circle">${circle}</span></div>
+          <div class="ex-rail-body">
+            <div class="dense-line edit-toggle" data-toggle-done="${i}">
+              <div class="ex-rail-name">${name}</div>
+              ${badge}
+            </div>
+            <div class="ex-rail-meta" style="margin:2px 0 0;">Tap a set to edit · tap the title to close</div>
+            <div class="sets-modern">
+              ${ex.sets.map((s, si) => setRowHtml(ex, i, si, false)).join('')}
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    const cls = ['ex-rail-step', skipped ? 'skipped' : 'completed', 'dense-collapsed'].join(' ');
     const summary = skipped
       ? (ex.sets.length ? `${esc(sessionExerciseSetSummary(ex))} · skipped rest` : 'Skipped this session')
       : ex.sets.map(s => `${fmtNum(s.weight)}×${s.reps}`).join(' · ');
+    const editAttr = editable ? ` data-toggle-done="${i}"` : '';
     return `
       <div class="${cls}" data-ex-idx="${i}">
         <div class="ex-rail-node"><span class="ex-rail-circle">${circle}</span></div>
-        <div class="ex-rail-body">
+        <div class="ex-rail-body${editable ? ' editable' : ''}"${editAttr}>
           <div class="dense-line">
             <div class="ex-rail-name">${name}</div>
             ${badge}
           </div>
-          <div class="dense-summary">${summary}</div>
+          <div class="dense-summary">${summary}${editable ? ' · tap to edit' : ''}</div>
         </div>
       </div>
     `;

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -6,6 +6,7 @@ function startWorkout(dayIndex) {
   const day = state.program.template[dayIndex];
   if (!day) return;
   editingSet = null;
+  expandedExIdx = null;
   selectedWeekIndex = state.currentRun.weekIndex || 0;
   expandedDayKey = dayKey(selectedWeekIndex, dayIndex);
   state.active = {
@@ -326,6 +327,7 @@ function finishWorkout(opts = {}) {
   else if (fullyComplete) buzz([30, 60, 30]);
   state.active = null;
   editingSet = null;
+  expandedExIdx = null;
   save();
   render();
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v21';
+const VERSION = 'v22';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',

--- a/styles.css
+++ b/styles.css
@@ -297,6 +297,9 @@
   }
   .dense-collapsed.completed .dense-summary { color: var(--success); }
   .dense-collapsed.skipped .dense-summary { color: var(--warn); }
+  .ex-rail-body.editable { cursor: pointer; -webkit-tap-highlight-color: transparent; }
+  .ex-rail-body.editable:active { opacity: 0.7; }
+  .ex-rail-step.expanded .dense-line.edit-toggle { cursor: pointer; }
   .ex-rail-step.dense-collapsed .dense-line { min-height: 32px; }
   .rail-eyebrow { color: var(--text-dim); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
   .rail-eyebrow.active { color: var(--accent); }


### PR DESCRIPTION
Tap a completed exercise in the workout rail to reopen it and edit any
logged set's weight or reps, reusing the existing edit-set machinery.
Tapping the title again collapses it.