### PR TITLE
Add GitHub Pages preview environments for pull requests

### DIFF
--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -1,0 +1,44 @@
+name: Cleanup pull request preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: public
+
+      - name: Remove preview folder
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd public
+          rm -rf "pr-${{ github.event.pull_request.number }}"
+
+      - name: Commit and push cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd public
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No preview cleanup changes."
+          else
+            git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}"
+            git push origin gh-pages
+          fi

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,121 @@
+name: Deploy pull request preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to deploy as a preview
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve preview details
+        id: preview
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "number=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+            echo "ref=refs/pull/${{ github.event.inputs.pr_number }}/head" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout pull request source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.preview.outputs.ref }}
+          path: site
+
+      - name: Prepare gh-pages branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git clone --branch gh-pages "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" public; then
+            echo "Using existing gh-pages branch."
+          else
+            mkdir public
+            cd public
+            git init
+            git checkout --orphan gh-pages
+            git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+            cd ..
+          fi
+
+      - name: Copy preview files
+        shell: bash
+        run: |
+          set -euo pipefail
+          preview_dir="public/pr-${{ steps.preview.outputs.number }}"
+          rm -rf "$preview_dir"
+          mkdir -p "$preview_dir"
+
+          rsync -a \
+            --exclude='.git' \
+            --exclude='.github' \
+            site/ "$preview_dir/"
+
+          touch public/.nojekyll
+
+      - name: Commit and push preview deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd public
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No preview deployment changes."
+          else
+            git commit -m "Deploy preview for PR #${{ steps.preview.outputs.number }}"
+            git push origin gh-pages
+          fi
+
+      - name: Comment with preview URL
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const url = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr-${prNumber}/`;
+            const marker = '<!-- pr-preview-url -->';
+            const body = `${marker}\nPreview environment: ${url}\n\nThis preview updates automatically whenever this pull request branch changes.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find(comment => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,74 @@
+name: Deploy production site
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout production source
+        uses: actions/checkout@v4
+        with:
+          path: site
+
+      - name: Prepare gh-pages branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git clone --branch gh-pages "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" public; then
+            echo "Using existing gh-pages branch."
+          else
+            mkdir public
+            cd public
+            git init
+            git checkout --orphan gh-pages
+            git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+            cd ..
+          fi
+
+      - name: Copy production files
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s dotglob nullglob
+
+          # Clear the production root while preserving PR preview folders.
+          for item in public/* public/.[!.]* public/..?*; do
+            base="$(basename "$item")"
+            if [[ "$base" != ".git" && "$base" != pr-* ]]; then
+              rm -rf "$item"
+            fi
+          done
+
+          rsync -a \
+            --exclude='.git' \
+            --exclude='.github' \
+            site/ public/
+
+          touch public/.nojekyll
+
+      - name: Commit and push production deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd public
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No production deployment changes."
+          else
+            git commit -m "Deploy production site"
+            git push origin gh-pages
+          fi


### PR DESCRIPTION
Adds GitHub Actions workflows for a lightweight preview environment setup for this static app.

What this does:
- Deploys production from `master` to the root of the `gh-pages` branch.
- Deploys each pull request preview to `/pr-<number>/` on the same GitHub Pages site.
- Comments the preview URL on the pull request.
- Removes the preview folder when the pull request is closed.

After merging this PR, update GitHub Pages settings:
1. Go to Settings → Pages.
2. Set Source to `Deploy from a branch`.
3. Select branch `gh-pages` and folder `/root`.
4. Save.
5. Run the `Deploy production site` workflow once from the Actions tab, or push a small change to `master`.

Important: until the workflow file exists on `master`, pull request preview automation will not reliably run for future PRs. Merge this setup PR first, then previews will work for new feature PRs.