### PR TITLE
Redesign workout tab: any-order completion with active selection + Co…

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -262,10 +262,23 @@ function onClick(e) {
     skipExercise(exIdx);
     return;
   }
-  // Reopen a completed exercise in the rail to edit its logged sets
+  // Tap an outstanding exercise to make it the active one
+  const selectActive = e.target.closest && e.target.closest('[data-select-active]');
+  if (selectActive) {
+    setActiveExercise(+selectActive.dataset.selectActive);
+    return;
+  }
+  // Collapse / expand the Completed section
+  if (e.target.closest && e.target.closest('[data-toggle-completed]')) {
+    completedCollapsed = !completedCollapsed;
+    render();
+    return;
+  }
+  // Reopen a completed exercise in the Completed section to edit its logged sets
   const toggleDone = e.target.closest && e.target.closest('[data-toggle-done]');
   if (toggleDone) {
     const idx = +toggleDone.dataset.toggleDone;
+    maybeFlushLinger(idx);
     expandedExIdx = (expandedExIdx === idx) ? null : idx;
     editingSet = null;
     render();
@@ -274,6 +287,7 @@ function onClick(e) {
   const editEl = e.target.closest && e.target.closest('[data-edit-set]');
   if (editEl) {
     const [exIdx, setIdx] = editEl.dataset.editSet.split(',').map(Number);
+    maybeFlushLinger(exIdx);
     editingSet = { exIdx, setIdx };
     render();
     return;

--- a/js/state.js
+++ b/js/state.js
@@ -164,7 +164,9 @@ function setState(patch) {
 let state = load();
 let setupDraft = null;  // { name, weeks, days: [...] } while editing in setup screen
 let editingSet = null;  // { exIdx, setIdx } when a logged set is being edited
-let expandedExIdx = null;  // index of a completed exercise expanded for editing in the rail
+let expandedExIdx = null;  // index of a completed exercise expanded for editing in the Completed section
+let lingeringExIdx = null; // a just-completed exercise still shown in place, awaiting the next action
+let completedCollapsed = true; // the Completed section starts collapsed
 let selectedWeekIndex = null; // UI-only selected week on Today
 let expandedDayKey = null;    // UI-only expanded Today day, formatted as "week:day"
 let exerciseLibrarySearch = '';

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -1,17 +1,34 @@
 Views.workout = function() {
   const a = state.active;
   if (!a) return workoutEmptyHtml();
-  const currentExIdx = a.exercises.findIndex(e => !exerciseIsResolved(e));
-  const allDone = currentExIdx === -1;
+  const activeIdx = currentActiveIdx();
+  const linger = validLingerIdx();
+  const allResolved = a.exercises.every(exerciseIsResolved);
 
   const dots = a.exercises.map((e, i) => {
     const done = exerciseIsComplete(e);
     const skipped = !!e.skipped;
-    const cur = i === currentExIdx;
+    const cur = i === activeIdx;
     return `<div class="dot ${done ? 'done' : ''} ${skipped ? 'skipped' : ''} ${cur ? 'current' : ''}" data-jump="${i}"></div>`;
   }).join('');
 
-  const steps = a.exercises.map((e, i) => exerciseRailStepHtml(e, i, currentExIdx)).join('');
+  // Outstanding (top) list — no heading. Order: lingering just-completed,
+  // then the active exercise, then the remaining unresolved exercises.
+  const order = [];
+  if (linger != null) order.push(linger);
+  if (activeIdx >= 0 && activeIdx !== linger) order.push(activeIdx);
+  a.exercises.forEach((e, i) => {
+    if (i === activeIdx || i === linger) return;
+    if (!exerciseIsResolved(e)) order.push(i);
+  });
+  const topHtml = order.map(i => {
+    if (i === linger) return lingerStepHtml(a.exercises[i], i);
+    if (i === activeIdx) return activeStepHtml(a.exercises[i], i);
+    return upNextStepHtml(a.exercises[i], i);
+  }).join('');
+
+  const topCard = topHtml ? `<div class="card"><div class="ex-rail">${topHtml}</div></div>` : '';
+  const completedCard = completedSectionHtml(a, linger);
 
   return `
     <div class="workout-top">
@@ -21,12 +38,11 @@ Views.workout = function() {
       </div>
       <div class="dots">${dots}</div>
     </div>
-    <div class="card">
-      <div class="ex-rail">${steps}</div>
-    </div>
+    ${topCard}
+    ${completedCard}
     <div class="workout-bottom">
       <div class="workout-bottom-inner">
-        <button class="btn ${allDone ? 'success' : ''}" id="finish-workout">${allDone ? 'Finish Workout ✓' : 'Finish Workout'}</button>
+        <button class="btn ${allResolved ? 'success' : ''}" id="finish-workout">${allResolved ? 'Finish Workout ✓' : 'Finish Workout'}</button>
       </div>
     </div>
   `;
@@ -50,93 +66,148 @@ function workoutEmptyHtml() {
   `;
 }
 
-function exerciseRailStepHtml(ex, i, currentExIdx) {
-  const complete = exerciseIsComplete(ex);
-  const skipped = !!ex.skipped;
-  const done = complete || skipped;
-  const isCurrent = !done && i === currentExIdx;
+// The active (blue) exercise — expanded with the set logger. Blank rail circle.
+function activeStepHtml(ex, i) {
   const name = esc(ex.name);
-
-  if (done) {
-    const circle = skipped ? '–' : '✓';
-    const badge = skipped
-      ? `<span class="badge warn">${ex.sets.length ? 'Skipped rest' : 'Skipped'}</span>`
-      : `<span class="badge success">${ex.sets.length}/${ex.targetSets} ✓</span>`;
-    // Only exercises with logged sets can be reopened to fix a typed value.
-    const editable = ex.sets.length > 0;
-    const expanded = editable && i === expandedExIdx;
-
-    if (expanded) {
-      return `
-        <div class="ex-rail-step ${skipped ? 'skipped' : 'completed'} expanded" data-ex-idx="${i}">
-          <div class="ex-rail-node"><span class="ex-rail-circle">${circle}</span></div>
-          <div class="ex-rail-body">
-            <div class="dense-line edit-toggle" data-toggle-done="${i}">
-              <div class="ex-rail-name">${name}</div>
-              ${badge}
-            </div>
-            <div class="ex-rail-meta" style="margin:2px 0 0;">Tap a set to edit · tap the title to close</div>
-            <div class="sets-modern">
-              ${ex.sets.map((s, si) => setRowHtml(ex, i, si, false)).join('')}
-            </div>
+  const skipLabel = ex.sets.length ? 'Skip Rest' : 'Skip';
+  return `
+    <div class="ex-rail-step active" data-ex-idx="${i}">
+      <div class="ex-rail-node"><span class="ex-rail-circle"></span></div>
+      <div class="ex-rail-body">
+        <div class="dense-line">
+          <div style="min-width:0;">
+            <div class="rail-eyebrow active">Active</div>
+            <div class="ex-rail-name" style="font-size:17px;">${name}</div>
+          </div>
+          <div class="row" style="gap:6px;">
+            <span class="badge">${ex.sets.length}/${ex.targetSets}</span>
+            <button class="btn ghost small skip-ex-btn" data-act="skip-ex" data-ex-idx="${i}">${skipLabel}</button>
           </div>
         </div>
-      `;
-    }
+        <div class="ex-rail-meta" style="margin:2px 0 0;">Target ${ex.targetSets} × ${ex.targetReps}</div>
+        <div class="sets-modern">
+          ${Array.from({length: ex.targetSets}, (_, si) => setRowHtml(ex, i, si, true)).join('')}
+        </div>
+      </div>
+    </div>
+  `;
+}
 
-    const cls = ['ex-rail-step', skipped ? 'skipped' : 'completed', 'dense-collapsed'].join(' ');
-    const summary = skipped
-      ? (ex.sets.length ? `${esc(sessionExerciseSetSummary(ex))} · skipped rest` : 'Skipped this session')
-      : ex.sets.map(s => `${fmtNum(s.weight)}×${s.reps}`).join(' · ');
-    const editAttr = editable ? ` data-toggle-done="${i}"` : '';
+// An outstanding exercise that isn't active yet — tap to make it active. Blank circle.
+function upNextStepHtml(ex, i) {
+  const name = esc(ex.name);
+  const started = ex.sets.length > 0;
+  const badge = started
+    ? `<span class="badge">${ex.sets.length}/${ex.targetSets}</span>`
+    : `<span class="badge muted">${ex.targetSets} × ${ex.targetReps}</span>`;
+  const summary = started
+    ? `${ex.sets.map(s => `${fmtNum(s.weight)}×${s.reps}`).join(' · ')} · tap to resume`
+    : 'Tap to start';
+  return `
+    <div class="ex-rail-step upcoming dense-collapsed" data-ex-idx="${i}">
+      <div class="ex-rail-node"><span class="ex-rail-circle"></span></div>
+      <div class="ex-rail-body selectable" data-select-active="${i}">
+        <div class="dense-line">
+          <div class="ex-rail-name">${name}</div>
+          ${badge}
+        </div>
+        <div class="dense-summary">${summary}</div>
+      </div>
+    </div>
+  `;
+}
+
+// A just-completed exercise lingering in place — stays editable until the next
+// action files it into the Completed section.
+function lingerStepHtml(ex, i) {
+  const name = esc(ex.name);
+  return `
+    <div class="ex-rail-step completed expanded linger" data-ex-idx="${i}">
+      <div class="ex-rail-node"><span class="ex-rail-circle">✓</span></div>
+      <div class="ex-rail-body">
+        <div class="dense-line">
+          <div style="min-width:0;">
+            <div class="rail-eyebrow done">Completed</div>
+            <div class="ex-rail-name">${name}</div>
+          </div>
+          <span class="badge success">${ex.sets.length}/${ex.targetSets} ✓</span>
+        </div>
+        <div class="ex-rail-meta" style="margin:2px 0 0;">Nice work — tap a set to fix it before it files away</div>
+        <div class="sets-modern">
+          ${ex.sets.map((s, si) => setRowHtml(ex, i, si, false)).join('')}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+// Collapsed "Completed (N)" section. N counts truly-completed exercises;
+// skipped exercises live here too but are noted separately, not counted.
+function completedSectionHtml(a, linger) {
+  const idxs = a.exercises
+    .map((e, i) => i)
+    .filter(i => i !== linger && exerciseIsResolved(a.exercises[i]));
+  if (!idxs.length) return '';
+  const completedCount = idxs.filter(i => exerciseIsComplete(a.exercises[i]) && !a.exercises[i].skipped).length;
+  const skippedN = idxs.filter(i => a.exercises[i].skipped).length;
+  const note = skippedN ? `<span class="completed-skip-note">${skippedN} skipped</span>` : '';
+  const body = completedCollapsed ? '' : `
+    <div class="ex-rail completed-list">
+      ${idxs.map(i => completedRowHtml(a.exercises[i], i)).join('')}
+    </div>`;
+  return `
+    <div class="card completed-card">
+      <button class="completed-header" data-toggle-completed type="button" aria-expanded="${!completedCollapsed}">
+        <span class="completed-title">Completed <span class="completed-count">${completedCount}</span></span>
+        <span class="row" style="gap:10px;">${note}<span class="completed-chevron ${completedCollapsed ? '' : 'open'}" aria-hidden="true">⌄</span></span>
+      </button>
+      ${body}
+    </div>
+  `;
+}
+
+// A row inside the Completed section — tap to expand and edit its logged sets.
+function completedRowHtml(ex, i) {
+  const skipped = !!ex.skipped;
+  const name = esc(ex.name);
+  const circle = skipped ? '–' : '✓';
+  const badge = skipped
+    ? `<span class="badge warn">${ex.sets.length ? 'Skipped rest' : 'Skipped'}</span>`
+    : `<span class="badge success">${ex.sets.length}/${ex.targetSets} ✓</span>`;
+  const editable = ex.sets.length > 0;
+  const expanded = editable && i === expandedExIdx;
+
+  if (expanded) {
     return `
-      <div class="${cls}" data-ex-idx="${i}">
+      <div class="ex-rail-step ${skipped ? 'skipped' : 'completed'} expanded" data-ex-idx="${i}">
         <div class="ex-rail-node"><span class="ex-rail-circle">${circle}</span></div>
-        <div class="ex-rail-body${editable ? ' editable' : ''}"${editAttr}>
-          <div class="dense-line">
+        <div class="ex-rail-body">
+          <div class="dense-line edit-toggle" data-toggle-done="${i}">
             <div class="ex-rail-name">${name}</div>
             ${badge}
           </div>
-          <div class="dense-summary">${summary}${editable ? ' · tap to edit' : ''}</div>
-        </div>
-      </div>
-    `;
-  }
-
-  if (isCurrent) {
-    const skipLabel = ex.sets.length ? 'Skip Rest' : 'Skip';
-    return `
-      <div class="ex-rail-step active" data-ex-idx="${i}">
-        <div class="ex-rail-node"><span class="ex-rail-circle">${i + 1}</span></div>
-        <div class="ex-rail-body">
-          <div class="dense-line">
-            <div style="min-width:0;">
-              <div class="rail-eyebrow active">In progress</div>
-              <div class="ex-rail-name" style="font-size:17px;">${name}</div>
-            </div>
-            <div class="row" style="gap:6px;">
-              <span class="badge">${ex.sets.length}/${ex.targetSets}</span>
-              <button class="btn ghost small skip-ex-btn" data-act="skip-ex" data-ex-idx="${i}">${skipLabel}</button>
-            </div>
-          </div>
-          <div class="ex-rail-meta" style="margin:2px 0 0;">Target ${ex.targetSets} × ${ex.targetReps}</div>
+          <div class="ex-rail-meta" style="margin:2px 0 0;">Tap a set to edit · tap the title to close</div>
           <div class="sets-modern">
-            ${Array.from({length: ex.targetSets}, (_, si) => setRowHtml(ex, i, si, true)).join('')}
+            ${ex.sets.map((s, si) => setRowHtml(ex, i, si, false)).join('')}
           </div>
         </div>
       </div>
     `;
   }
 
-  // Pending — collapsed
+  const summary = skipped
+    ? (ex.sets.length ? `${esc(sessionExerciseSetSummary(ex))} · skipped rest` : 'Skipped this session')
+    : ex.sets.map(s => `${fmtNum(s.weight)}×${s.reps}`).join(' · ');
+  const editAttr = editable ? ` data-toggle-done="${i}"` : '';
   return `
-    <div class="ex-rail-step upcoming dense-collapsed" data-ex-idx="${i}">
-      <div class="ex-rail-node"><span class="ex-rail-circle">${i + 1}</span></div>
-      <div class="ex-rail-body">
+    <div class="ex-rail-step ${skipped ? 'skipped' : 'completed'} dense-collapsed" data-ex-idx="${i}">
+      <div class="ex-rail-node"><span class="ex-rail-circle">${circle}</span></div>
+      <div class="ex-rail-body${editable ? ' editable' : ''}"${editAttr}>
         <div class="dense-line">
           <div class="ex-rail-name">${name}</div>
-          <span class="badge muted">${ex.targetSets} × ${ex.targetReps}</span>
+          ${badge}
         </div>
+        <div class="dense-summary">${summary}${editable ? ' · tap to edit' : ''}</div>
       </div>
     </div>
   `;

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -7,6 +7,8 @@ function startWorkout(dayIndex) {
   if (!day) return;
   editingSet = null;
   expandedExIdx = null;
+  lingeringExIdx = null;
+  completedCollapsed = true;
   selectedWeekIndex = state.currentRun.weekIndex || 0;
   expandedDayKey = dayKey(selectedWeekIndex, dayIndex);
   state.active = {
@@ -16,6 +18,7 @@ function startWorkout(dayIndex) {
     dayIndex,
     dayName: day.name || ('Workout ' + (dayIndex + 1)),
     startedAt: Date.now(),
+    activeExIdx: 0,
     exercises: day.exercises.map(e => ({
       name: e.name,
       targetSets: e.sets,
@@ -27,6 +30,120 @@ function startWorkout(dayIndex) {
   state.tab = 'workout';
   save();
   render();
+}
+
+/* ---------- Active-exercise selection (any-order) ---------- */
+// The active (blue) exercise. Stored on state.active for reload-resilience;
+// recomputed to the first unresolved exercise if missing or stale.
+function currentActiveIdx() {
+  const a = state.active;
+  if (!a) return -1;
+  let idx = a.activeExIdx;
+  if (idx == null || idx < 0 || idx >= a.exercises.length || exerciseIsResolved(a.exercises[idx])) {
+    idx = a.exercises.findIndex(e => !exerciseIsResolved(e));
+    a.activeExIdx = idx;
+  }
+  return idx;
+}
+
+// The just-completed exercise still shown in place, or null if none/invalid.
+function validLingerIdx() {
+  const a = state.active;
+  if (!a || lingeringExIdx == null) return null;
+  const ex = a.exercises[lingeringExIdx];
+  if (!ex || !exerciseIsResolved(ex)) { lingeringExIdx = null; return null; }
+  return lingeringExIdx;
+}
+
+// First unresolved exercise after `idx`, wrapping around. -1 if all resolved.
+function nextUnresolvedAfter(idx) {
+  const a = state.active;
+  if (!a) return -1;
+  const n = a.exercises.length;
+  for (let k = 1; k <= n; k++) {
+    const j = (idx + k) % n;
+    if (!exerciseIsResolved(a.exercises[j])) return j;
+  }
+  return -1;
+}
+
+// Engaging any exercise other than the lingering one files the lingering one
+// down into the Completed section.
+function maybeFlushLinger(exIdx) {
+  if (lingeringExIdx != null && lingeringExIdx !== exIdx) lingeringExIdx = null;
+}
+
+// User taps an outstanding exercise to make it active.
+function setActiveExercise(idx) {
+  const a = state.active;
+  if (!a || idx < 0 || idx >= a.exercises.length) return;
+  if (exerciseIsResolved(a.exercises[idx])) return;
+  if (idx === a.activeExIdx && lingeringExIdx == null) return;
+  maybeFlushLinger(idx);
+  a.activeExIdx = idx;
+  editingSet = null;
+  renderRailReorder();
+}
+
+/* ---------- Rail reorder animation (FLIP) ---------- */
+function captureRailState() {
+  const map = new Map();
+  document.querySelectorAll('.ex-rail [data-ex-idx]').forEach(el => {
+    map.set(el.getAttribute('data-ex-idx'), { rect: el.getBoundingClientRect(), clone: el.cloneNode(true) });
+  });
+  return map;
+}
+
+function playRailReorder(prev) {
+  if (!prev || !prev.size) return;
+  if (!Element.prototype.animate) return; // no Web Animations API — skip gracefully
+  const seen = new Set();
+  document.querySelectorAll('.ex-rail [data-ex-idx]').forEach(el => {
+    const id = el.getAttribute('data-ex-idx');
+    seen.add(id);
+    const before = prev.get(id);
+    if (!before) {
+      el.animate(
+        [{ opacity: 0, transform: 'translateY(-6px)' }, { opacity: 1, transform: 'none' }],
+        { duration: 220, easing: 'ease-out' }
+      );
+      return;
+    }
+    const after = el.getBoundingClientRect();
+    const dy = before.rect.top - after.top;
+    if (Math.abs(dy) < 2) return;
+    el.animate(
+      [{ transform: `translateY(${dy}px)` }, { transform: 'translateY(0)' }],
+      { duration: 340, easing: 'cubic-bezier(.2,.7,.2,1)' }
+    );
+  });
+
+  // Anything that disappeared (e.g. filed into a collapsed Completed section)
+  // fades out from where it was via a floating ghost.
+  prev.forEach((info, id) => {
+    if (seen.has(id)) return;
+    const r = info.rect;
+    if (r.width === 0 && r.height === 0) return;
+    const ghost = info.clone;
+    Object.assign(ghost.style, {
+      position: 'fixed', left: r.left + 'px', top: r.top + 'px', width: r.width + 'px',
+      margin: '0', zIndex: '5', pointerEvents: 'none'
+    });
+    document.body.appendChild(ghost);
+    const anim = ghost.animate(
+      [{ opacity: 1, transform: 'translateY(0) scale(1)' }, { opacity: 0, transform: 'translateY(10px) scale(0.97)' }],
+      { duration: 240, easing: 'ease-in' }
+    );
+    anim.onfinish = anim.oncancel = () => ghost.remove();
+  });
+}
+
+// Save + render, animating any rail steps that changed position or filed away.
+function renderRailReorder() {
+  const prev = captureRailState();
+  save();
+  render();
+  requestAnimationFrame(() => playRailReorder(prev));
 }
 
 function withUnloggedSetGuard(next, continueText) {
@@ -78,16 +195,13 @@ function skipExercise(exIdx) {
   if (!ex || exerciseIsResolved(ex)) return;
 
   const applySkip = () => {
+    maybeFlushLinger(exIdx);
     ex.skipped = true;
     ex.skippedAt = Date.now();
     editingSet = null;
+    a.activeExIdx = nextUnresolvedAfter(exIdx);
     closeModal();
-    save();
-    render();
-    requestAnimationFrame(() => {
-      const nextStep = document.querySelector('.ex-rail-step.active');
-      if (nextStep) nextStep.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    });
+    renderRailReorder();
   };
 
   showModal({
@@ -173,13 +287,18 @@ function logCurrentSet(row) {
   if (!card) return;
   const exIdx = +card.dataset.exIdx;
   const ex = state.active.exercises[exIdx];
+
+  // Logging on the active exercise is the "next action" that files away any
+  // previously lingering completed exercise.
+  maybeFlushLinger(exIdx);
+
   ex.sets.push({ weight: w, reps: r, ts: Date.now() });
   const stillSameEx = ex.sets.length < ex.targetSets;
   buzz(stillSameEx ? 12 : [20, 40, 20]);
-  save();
   startRest();
 
   if (stillSameEx) {
+    save();
     // In-place advance: patch only this exercise's set rows + counter so the
     // input stays responsive and we avoid re-rendering the whole rail.
     const setsWrap = card.querySelector('.sets-modern');
@@ -196,12 +315,11 @@ function logCurrentSet(row) {
     return;
   }
 
-  // Exercise finished — full render to collapse it and advance the rail.
-  render();
-  requestAnimationFrame(() => {
-    const nextStep = document.querySelector('.ex-rail-step.active');
-    if (nextStep) nextStep.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  });
+  // Exercise complete — it lingers in place (editable) while the next
+  // unresolved exercise auto-becomes active. Animate the reorder.
+  lingeringExIdx = exIdx;
+  state.active.activeExIdx = nextUnresolvedAfter(exIdx);
+  renderRailReorder();
 }
 
 function finishWorkout(opts = {}) {
@@ -212,6 +330,8 @@ function finishWorkout(opts = {}) {
   if (!sessionExercises.length) {
     state.active = null;
     editingSet = null;
+    lingeringExIdx = null;
+    completedCollapsed = true;
     save();
     render();
     return;
@@ -328,6 +448,8 @@ function finishWorkout(opts = {}) {
   state.active = null;
   editingSet = null;
   expandedExIdx = null;
+  lingeringExIdx = null;
+  completedCollapsed = true;
   save();
   render();
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v22';
+const VERSION = 'v23';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',

--- a/styles.css
+++ b/styles.css
@@ -303,7 +303,36 @@
   .ex-rail-step.dense-collapsed .dense-line { min-height: 32px; }
   .rail-eyebrow { color: var(--text-dim); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
   .rail-eyebrow.active { color: var(--accent); }
+  .rail-eyebrow.done { color: var(--success); }
   .skip-ex-btn { flex-shrink: 0; }
+
+  /* Tap an up-next exercise to make it active */
+  .ex-rail-body.selectable { cursor: pointer; -webkit-tap-highlight-color: transparent; }
+  .ex-rail-body.selectable:active { opacity: 0.7; }
+
+  /* Just-completed exercise lingering in place before it files away */
+  .ex-rail-step.linger .ex-rail-body {
+    animation: wt-linger-in 260ms ease-out;
+  }
+  @keyframes wt-linger-in { from { background: var(--success-dim); } to { background: transparent; } }
+
+  /* Completed section */
+  .completed-card { padding: 0; overflow: hidden; }
+  .completed-header {
+    width: 100%; display: flex; align-items: center; justify-content: space-between;
+    gap: 10px; padding: 15px 16px; background: none; border: 0; cursor: pointer;
+    color: var(--text); font: inherit; -webkit-tap-highlight-color: transparent;
+  }
+  .completed-title { font-size: 15px; font-weight: 700; display: inline-flex; align-items: center; gap: 8px; }
+  .completed-count {
+    min-width: 22px; height: 22px; padding: 0 7px; border-radius: 11px;
+    background: var(--success); color: white; font-size: 12.5px; font-weight: 700;
+    display: inline-flex; align-items: center; justify-content: center; font-variant-numeric: tabular-nums;
+  }
+  .completed-skip-note { color: var(--warn); font-size: 12.5px; font-weight: 600; }
+  .completed-chevron { color: var(--text-dim); font-size: 16px; transition: transform 0.2s ease; }
+  .completed-chevron.open { transform: rotate(180deg); }
+  .completed-list { padding: 0 16px 16px; }
 
   /* Active node pulse */
   @keyframes wt-pulse-accent { 0%, 100% { box-shadow: 0 0 0 5px var(--accent-dim); } 50% { box-shadow: 0 0 0 8px var(--accent-dim); } }


### PR DESCRIPTION
…mpleted section

- Exercises complete in any order; tap any outstanding exercise to make it the active (blue) one, which animates to the top.
- Completed/skipped exercises file into a collapsed 'Completed (N)' section; skipped items are noted separately and not counted.
- A just-completed exercise lingers in place (editable inline) until the next action, then slides/fades into the Completed section.
- Completing or skipping auto-selects the next unresolved exercise as active.
- Vertical rail circles are now blank (no numbers); set-number labels within an exercise are kept since sets have an order.
- FLIP-based reorder animations via the Web Animations API.