### PR TITLE
Workout: manual next-exercise selection, add-set, swipe-to-delete sets

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -1,9 +1,76 @@
 /* ---------- Event handling ---------- */
+const SWIPE_REVEAL = 72; // px the set face slides to expose the trash button
+let swipe = null;
+let suppressNextClick = false;
+
 function bindGlobalEvents() {
   document.addEventListener('click', onClick);
   document.addEventListener('input', onInput);
   document.addEventListener('keydown', onKeydown);
   document.addEventListener('focusin', onFocusIn);
+  document.addEventListener('touchstart', onTouchStart, { passive: true });
+  document.addEventListener('touchmove', onTouchMove, { passive: false });
+  document.addEventListener('touchend', onTouchEnd);
+  document.addEventListener('touchcancel', onTouchEnd);
+}
+
+/* ---------- Swipe-to-reveal delete on logged set rows ---------- */
+function closeAllReveals(except) {
+  document.querySelectorAll('.set-row.revealed').forEach(el => {
+    if (el !== except) el.classList.remove('revealed');
+  });
+}
+
+function onTouchStart(e) {
+  // A fresh touch is deliberate intent — never suppress its click.
+  suppressNextClick = false;
+  if (e.touches.length !== 1) { swipe = null; return; }
+  const wrap = e.target.closest && e.target.closest('.set-row.swipe-wrap');
+  // Don't begin a swipe from the trash button itself.
+  if (!wrap || (e.target.closest && e.target.closest('.set-delete'))) { swipe = null; return; }
+  const face = wrap.querySelector('.set-row-face');
+  if (!face) { swipe = null; return; }
+  const t = e.touches[0];
+  swipe = {
+    wrap, face,
+    startX: t.clientX, startY: t.clientY,
+    base: wrap.classList.contains('revealed') ? -SWIPE_REVEAL : 0,
+    horizontal: false, vertical: false, curr: null
+  };
+}
+
+function onTouchMove(e) {
+  if (!swipe) return;
+  const t = e.touches[0];
+  const dx = t.clientX - swipe.startX;
+  const dy = t.clientY - swipe.startY;
+  if (!swipe.horizontal && !swipe.vertical) {
+    if (Math.abs(dx) > 8 && Math.abs(dx) > Math.abs(dy)) swipe.horizontal = true;
+    else if (Math.abs(dy) > 8) swipe.vertical = true;
+  }
+  if (swipe.vertical) { swipe = null; return; } // it's a scroll — let it through
+  if (!swipe.horizontal) return;
+  e.preventDefault(); // claim the gesture so the page doesn't scroll
+  let tx = Math.max(-SWIPE_REVEAL, Math.min(0, swipe.base + dx));
+  swipe.curr = tx;
+  swipe.face.style.transition = 'none';
+  swipe.face.style.transform = `translateX(${tx}px)`;
+}
+
+function onTouchEnd() {
+  if (!swipe) return;
+  const s = swipe;
+  swipe = null;
+  if (!s.horizontal) return;
+  // Hand the snap back to the CSS class transition.
+  s.face.style.transition = '';
+  s.face.style.transform = '';
+  const shouldReveal = (s.curr != null ? s.curr : s.base) <= -SWIPE_REVEAL / 2;
+  closeAllReveals(s.wrap);
+  s.wrap.classList.toggle('revealed', shouldReveal);
+  // A horizontal swipe must not also fire the tap-to-edit click.
+  suppressNextClick = true;
+  setTimeout(() => { suppressNextClick = false; }, 400);
 }
 
 function onFocusIn(e) {
@@ -14,6 +81,22 @@ function onFocusIn(e) {
 }
 
 function onClick(e) {
+  // A just-finished swipe shouldn't trigger a tap action.
+  if (suppressNextClick) { suppressNextClick = false; return; }
+
+  // Tap the revealed trash button to delete that set.
+  const delBtn = e.target.closest && e.target.closest('[data-act="delete-set"]');
+  if (delBtn) {
+    const [exIdx, si] = delBtn.dataset.delSet.split(',').map(Number);
+    removeSet(exIdx, si);
+    return;
+  }
+  // With a set swiped open, the next tap anywhere just closes it.
+  if (document.querySelector('.set-row.revealed')) {
+    closeAllReveals(null);
+    return;
+  }
+
   const t = e.target.closest('[data-tab]');
   if (t) {
     setState({ tab: t.dataset.tab });
@@ -260,6 +343,12 @@ function onClick(e) {
     const exIdx = parseInt(e.target.dataset.exIdx, 10);
     if (withUnloggedSetGuard(() => skipExercise(exIdx), 'Skip without set')) return;
     skipExercise(exIdx);
+    return;
+  }
+  // "+ Add set" — append an extra loggable set to an exercise
+  const addSetBtn = e.target.closest && e.target.closest('[data-act="add-set"]');
+  if (addSetBtn) {
+    addSet(+addSetBtn.dataset.exIdx);
     return;
   }
   // Tap an outstanding exercise to make it the active one

--- a/js/utils.js
+++ b/js/utils.js
@@ -31,8 +31,12 @@ function totalVolume(exercises) {
 function setCount(exercises) {
   return exercises.reduce((n, e) => n + e.sets.length, 0);
 }
+function exerciseSlots(ex) {
+  // Target sets plus any extra sets the user added mid-workout.
+  return ex.targetSets + (ex.extraSets || 0);
+}
 function exerciseIsComplete(ex) {
-  return ex.sets.length >= ex.targetSets;
+  return ex.sets.length >= exerciseSlots(ex);
 }
 function exerciseIsResolved(ex) {
   return exerciseIsComplete(ex) || !!ex.skipped;

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -80,17 +80,23 @@ function activeStepHtml(ex, i) {
             <div class="ex-rail-name" style="font-size:17px;">${name}</div>
           </div>
           <div class="row" style="gap:6px;">
-            <span class="badge">${ex.sets.length}/${ex.targetSets}</span>
+            <span class="badge">${ex.sets.length}/${exerciseSlots(ex)}</span>
             <button class="btn ghost small skip-ex-btn" data-act="skip-ex" data-ex-idx="${i}">${skipLabel}</button>
           </div>
         </div>
         <div class="ex-rail-meta" style="margin:2px 0 0;">Target ${ex.targetSets} × ${ex.targetReps}</div>
         <div class="sets-modern">
-          ${Array.from({length: ex.targetSets}, (_, si) => setRowHtml(ex, i, si, true)).join('')}
+          ${Array.from({length: exerciseSlots(ex)}, (_, si) => setRowHtml(ex, i, si, true)).join('')}
         </div>
+        ${addSetBtnHtml(i)}
       </div>
     </div>
   `;
+}
+
+// "+ Add set" — appends one more loggable set beyond the allocated target.
+function addSetBtnHtml(exIdx) {
+  return `<button type="button" class="add-set-btn" data-act="add-set" data-ex-idx="${exIdx}">+ Add set</button>`;
 }
 
 // An outstanding exercise that isn't active yet — tap to make it active. Blank circle.
@@ -98,7 +104,7 @@ function upNextStepHtml(ex, i) {
   const name = esc(ex.name);
   const started = ex.sets.length > 0;
   const badge = started
-    ? `<span class="badge">${ex.sets.length}/${ex.targetSets}</span>`
+    ? `<span class="badge">${ex.sets.length}/${exerciseSlots(ex)}</span>`
     : `<span class="badge muted">${ex.targetSets} × ${ex.targetReps}</span>`;
   const summary = started
     ? `${ex.sets.map(s => `${fmtNum(s.weight)}×${s.reps}`).join(' · ')} · tap to resume`
@@ -130,12 +136,13 @@ function lingerStepHtml(ex, i) {
             <div class="rail-eyebrow done">Completed</div>
             <div class="ex-rail-name">${name}</div>
           </div>
-          <span class="badge success">${ex.sets.length}/${ex.targetSets} ✓</span>
+          <span class="badge success">${ex.sets.length}/${exerciseSlots(ex)} ✓</span>
         </div>
-        <div class="ex-rail-meta" style="margin:2px 0 0;">Nice work — tap a set to fix it before it files away</div>
+        <div class="ex-rail-meta" style="margin:2px 0 0;">Nice work — edit, add a set, or pick the next exercise</div>
         <div class="sets-modern">
           ${ex.sets.map((s, si) => setRowHtml(ex, i, si, false)).join('')}
         </div>
+        ${addSetBtnHtml(i)}
       </div>
     </div>
   `;
@@ -173,7 +180,7 @@ function completedRowHtml(ex, i) {
   const circle = skipped ? '–' : '✓';
   const badge = skipped
     ? `<span class="badge warn">${ex.sets.length ? 'Skipped rest' : 'Skipped'}</span>`
-    : `<span class="badge success">${ex.sets.length}/${ex.targetSets} ✓</span>`;
+    : `<span class="badge success">${ex.sets.length}/${exerciseSlots(ex)} ✓</span>`;
   const editable = ex.sets.length > 0;
   const expanded = editable && i === expandedExIdx;
 
@@ -186,10 +193,11 @@ function completedRowHtml(ex, i) {
             <div class="ex-rail-name">${name}</div>
             ${badge}
           </div>
-          <div class="ex-rail-meta" style="margin:2px 0 0;">Tap a set to edit · tap the title to close</div>
+          <div class="ex-rail-meta" style="margin:2px 0 0;">Tap a set to edit · swipe a set to delete · tap the title to close</div>
           <div class="sets-modern">
             ${ex.sets.map((s, si) => setRowHtml(ex, i, si, false)).join('')}
           </div>
+          ${addSetBtnHtml(i)}
         </div>
       </div>
     `;
@@ -234,12 +242,18 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
   }
 
   if (logged) {
+    // Swipe the face left to reveal the trash button; tap the face to edit.
     return `
-      <div class="set-row logged" data-edit-set="${exIdx},${si}">
-        <span class="lbl">${si + 1}</span>
-        <span class="val">${fmtNum(logged.weight)} kg</span>
-        <span class="val">× ${logged.reps}</span>
-        <span class="set-check" aria-hidden="true">✓</span>
+      <div class="set-row logged swipe-wrap" data-set-idx="${si}">
+        <button type="button" class="set-delete" data-act="delete-set" data-del-set="${exIdx},${si}" aria-label="Delete set" tabindex="-1">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14M10 11v6M14 11v6"/></svg>
+        </button>
+        <div class="set-row-face" data-edit-set="${exIdx},${si}">
+          <span class="lbl">${si + 1}</span>
+          <span class="val">${fmtNum(logged.weight)} kg</span>
+          <span class="val">× ${logged.reps}</span>
+          <span class="set-check" aria-hidden="true">✓</span>
+        </div>
       </div>
     `;
   }

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -33,15 +33,17 @@ function startWorkout(dayIndex) {
 }
 
 /* ---------- Active-exercise selection (any-order) ---------- */
-// The active (blue) exercise. Stored on state.active for reload-resilience;
-// recomputed to the first unresolved exercise if missing or stale.
+// The active (blue) exercise, stored on state.active for reload-resilience.
+// -1 means nothing is selected — after completing an exercise we deliberately
+// leave the selection empty so the user picks the next one themselves.
 function currentActiveIdx() {
   const a = state.active;
   if (!a) return -1;
-  let idx = a.activeExIdx;
-  if (idx == null || idx < 0 || idx >= a.exercises.length || exerciseIsResolved(a.exercises[idx])) {
-    idx = a.exercises.findIndex(e => !exerciseIsResolved(e));
-    a.activeExIdx = idx;
+  const idx = a.activeExIdx;
+  if (idx == null) return -1;
+  if (idx < 0 || idx >= a.exercises.length || exerciseIsResolved(a.exercises[idx])) {
+    a.activeExIdx = -1;
+    return -1;
   }
   return idx;
 }
@@ -55,22 +57,22 @@ function validLingerIdx() {
   return lingeringExIdx;
 }
 
-// First unresolved exercise after `idx`, wrapping around. -1 if all resolved.
-function nextUnresolvedAfter(idx) {
-  const a = state.active;
-  if (!a) return -1;
-  const n = a.exercises.length;
-  for (let k = 1; k <= n; k++) {
-    const j = (idx + k) % n;
-    if (!exerciseIsResolved(a.exercises[j])) return j;
-  }
-  return -1;
-}
-
 // Engaging any exercise other than the lingering one files the lingering one
 // down into the Completed section.
 function maybeFlushLinger(exIdx) {
   if (lingeringExIdx != null && lingeringExIdx !== exIdx) lingeringExIdx = null;
+}
+
+// Drop any "Add set" slots that were never filled on exercises the user has
+// moved on from, so an abandoned extra slot doesn't leave them stuck incomplete.
+function reclaimExtraSlots(exceptIdx) {
+  const a = state.active;
+  if (!a) return;
+  a.exercises.forEach((ex, i) => {
+    if (i === exceptIdx) return;
+    const min = Math.max(0, ex.sets.length - ex.targetSets);
+    if ((ex.extraSets || 0) > min) ex.extraSets = min;
+  });
 }
 
 // User taps an outstanding exercise to make it active.
@@ -79,9 +81,72 @@ function setActiveExercise(idx) {
   if (!a || idx < 0 || idx >= a.exercises.length) return;
   if (exerciseIsResolved(a.exercises[idx])) return;
   if (idx === a.activeExIdx && lingeringExIdx == null) return;
+  reclaimExtraSlots(idx);
   maybeFlushLinger(idx);
   a.activeExIdx = idx;
   editingSet = null;
+  renderRailReorder();
+}
+
+// "+ Add set" — give an exercise one more loggable set and focus it.
+function addSet(exIdx) {
+  const a = state.active;
+  if (!a) return;
+  const ex = a.exercises[exIdx];
+  if (!ex) return;
+
+  // Preserve any half-typed value in the on-screen active row before re-render.
+  let typed = null;
+  const liveRow = document.querySelector(`[data-ex-idx="${exIdx}"] .set-row.active`);
+  if (liveRow && liveRow.dataset.dirty === '1') {
+    typed = {
+      w: (liveRow.querySelector('.set-w') || {}).value || '',
+      r: (liveRow.querySelector('.set-r') || {}).value || ''
+    };
+  }
+
+  ex.extraSets = (ex.extraSets || 0) + 1;
+  ex.skipped = false;
+  if (lingeringExIdx === exIdx) lingeringExIdx = null;
+  else maybeFlushLinger(exIdx);
+  a.activeExIdx = exIdx;
+  expandedExIdx = null;
+  editingSet = null;
+  renderRailReorder();
+
+  requestAnimationFrame(() => {
+    const card = document.querySelector(`.ex-rail-step.active[data-ex-idx="${exIdx}"]`);
+    const row = card && card.querySelector('.set-row.active');
+    if (!row) return;
+    if (typed) {
+      const w = row.querySelector('.set-w');
+      const rH = row.querySelector('.set-r');
+      const rD = row.querySelector('.reps-stepper .step-val');
+      if (w) w.value = typed.w;
+      if (rH) rH.value = typed.r;
+      if (rD && typed.r) rD.textContent = typed.r;
+      row.dataset.dirty = '1';
+      updateLogBtn(row);
+    }
+    const w = row.querySelector('.set-w');
+    if (w) w.focus();
+  });
+}
+
+// Swipe-to-delete a logged set.
+function removeSet(exIdx, si) {
+  const a = state.active;
+  if (!a) return;
+  const ex = a.exercises[exIdx];
+  if (!ex || !ex.sets[si]) return;
+  ex.sets.splice(si, 1);
+  if (ex.extraSets > 0) ex.extraSets -= 1;
+  editingSet = null;
+  // If the deletion leaves the exercise unfinished, keep the user focused on it.
+  if (!exerciseIsResolved(ex)) {
+    if (lingeringExIdx === exIdx) lingeringExIdx = null;
+    a.activeExIdx = exIdx;
+  }
   renderRailReorder();
 }
 
@@ -199,7 +264,7 @@ function skipExercise(exIdx) {
     ex.skipped = true;
     ex.skippedAt = Date.now();
     editingSet = null;
-    a.activeExIdx = nextUnresolvedAfter(exIdx);
+    a.activeExIdx = -1; // user selects the next exercise themselves
     closeModal();
     renderRailReorder();
   };
@@ -217,6 +282,7 @@ function skipExercise(exIdx) {
 function endWorkoutFlow() {
   const a = state.active;
   if (!a) return;
+  reclaimExtraSlots(-1); // drop any unfilled added slots before resolving status
   const fullyComplete = a.exercises.every(exerciseIsResolved);
   const anyLogged = a.exercises.some(e => e.sets.length > 0);
   const anySkipped = a.exercises.some(e => e.skipped);
@@ -293,7 +359,7 @@ function logCurrentSet(row) {
   maybeFlushLinger(exIdx);
 
   ex.sets.push({ weight: w, reps: r, ts: Date.now() });
-  const stillSameEx = ex.sets.length < ex.targetSets;
+  const stillSameEx = ex.sets.length < exerciseSlots(ex);
   buzz(stillSameEx ? 12 : [20, 40, 20]);
   startRest();
 
@@ -303,11 +369,11 @@ function logCurrentSet(row) {
     // input stays responsive and we avoid re-rendering the whole rail.
     const setsWrap = card.querySelector('.sets-modern');
     if (setsWrap) {
-      setsWrap.innerHTML = Array.from({ length: ex.targetSets },
+      setsWrap.innerHTML = Array.from({ length: exerciseSlots(ex) },
         (_, si) => setRowHtml(ex, exIdx, si, true)).join('');
     }
     const badge = card.querySelector('.dense-line .badge');
-    if (badge) badge.textContent = `${ex.sets.length}/${ex.targetSets}`;
+    if (badge) badge.textContent = `${ex.sets.length}/${exerciseSlots(ex)}`;
     requestAnimationFrame(() => {
       const next = card.querySelector('.set-row.active .set-w');
       if (next && document.activeElement !== next) next.focus();
@@ -315,10 +381,10 @@ function logCurrentSet(row) {
     return;
   }
 
-  // Exercise complete — it lingers in place (editable) while the next
-  // unresolved exercise auto-becomes active. Animate the reorder.
+  // Exercise complete — it lingers in place (editable). We do NOT auto-advance:
+  // the user selects the next exercise so they can tweak this one first.
   lingeringExIdx = exIdx;
-  state.active.activeExIdx = nextUnresolvedAfter(exIdx);
+  state.active.activeExIdx = -1;
   renderRailReorder();
 }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v23';
+const VERSION = 'v24';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',

--- a/styles.css
+++ b/styles.css
@@ -450,6 +450,42 @@
   .set-row.editing .edit-actions .log-btn:disabled { background: var(--border); color: var(--text-faint); }
   .set-row.editing .edit-actions .cancel-btn { background: var(--card); color: var(--text-dim); border: 1px solid var(--border); }
 
+  /* "+ Add set" button under an exercise's set list */
+  .add-set-btn {
+    display: block; width: 100%; margin-top: 7px;
+    padding: 9px; border: 1px dashed var(--border); border-radius: 11px;
+    background: transparent; color: var(--text-dim);
+    font-size: 13px; font-weight: 600; cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .add-set-btn:active { background: var(--bg); }
+
+  /* Swipe-to-reveal delete on a logged set row */
+  .set-row.swipe-wrap {
+    display: block; position: relative; overflow: hidden;
+    padding: 0; background: transparent; border-radius: 11px;
+    touch-action: pan-y;
+  }
+  .set-row.swipe-wrap .set-row-face {
+    display: grid;
+    grid-template-columns: 26px 1fr 1fr 44px;
+    gap: 9px; align-items: center;
+    background: var(--success-dim);
+    border-radius: 11px; padding: 8px 11px;
+    box-sizing: border-box; position: relative; z-index: 1;
+    cursor: pointer; -webkit-tap-highlight-color: transparent;
+    transition: transform 0.22s cubic-bezier(.2,.7,.2,1);
+    will-change: transform;
+  }
+  .set-row.swipe-wrap .set-row-face:active { filter: brightness(0.96); }
+  .set-row.swipe-wrap.revealed .set-row-face { transform: translateX(-72px); }
+  .set-delete {
+    position: absolute; top: 0; right: 0; bottom: 0; width: 72px;
+    display: flex; align-items: center; justify-content: center;
+    border: 0; border-radius: 11px; background: var(--danger, #e5484d);
+    color: white; cursor: pointer; z-index: 0;
+  }
+
   /* "Last time" reference below the active row — tap to copy into the set */
   .last-chip {
     display: inline-flex; align-items: center;


### PR DESCRIPTION
1. Completing an exercise no longer auto-advances. The finished exercise lingers in place (editable) and the user explicitly taps the next exercise to make it active — a cleaner transition for last-minute edits. Skipping likewise leaves selection to the user.
2. '+ Add set' button under each exercise's set list logs more than the allocated target. Unfilled added slots are reclaimed when the user moves on so they never leave an exercise stuck incomplete.
3. Swipe a logged set left to reveal a trash button; tap it to delete the set. Deleting refocuses the exercise if it becomes unfinished.