### PR TITLE
Make swipe-to-delete work on active and upcoming set rows

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -26,8 +26,9 @@ function onTouchStart(e) {
   suppressNextClick = false;
   if (e.touches.length !== 1) { swipe = null; return; }
   const wrap = e.target.closest && e.target.closest('.set-row.swipe-wrap');
-  // Don't begin a swipe from the trash button itself.
-  if (!wrap || (e.target.closest && e.target.closest('.set-delete'))) { swipe = null; return; }
+  // Don't begin a swipe from the trash button or from a text input (so the
+  // active row's weight field keeps its native touch behaviour).
+  if (!wrap || (e.target.closest && e.target.closest('.set-delete, input'))) { swipe = null; return; }
   const face = wrap.querySelector('.set-row-face');
   if (!face) { swipe = null; return; }
   const t = e.touches[0];

--- a/js/utils.js
+++ b/js/utils.js
@@ -32,8 +32,10 @@ function setCount(exercises) {
   return exercises.reduce((n, e) => n + e.sets.length, 0);
 }
 function exerciseSlots(ex) {
-  // Target sets plus any extra sets the user added mid-workout.
-  return ex.targetSets + (ex.extraSets || 0);
+  // Target sets plus the user's mid-workout adjustment (extraSets, which may be
+  // negative if they deleted planned sets). Never fewer than the logged sets,
+  // and never below one.
+  return Math.max(1, ex.sets.length, ex.targetSets + (ex.extraSets || 0));
 }
 function exerciseIsComplete(ex) {
   return ex.sets.length >= exerciseSlots(ex);

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -221,12 +221,19 @@ function completedRowHtml(ex, i) {
   `;
 }
 
+const TRASH_SVG = '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14M10 11v6M14 11v6"/></svg>';
+
+function setDeleteBtnHtml(exIdx, si) {
+  return `<button type="button" class="set-delete" data-act="delete-set" data-del-set="${exIdx},${si}" aria-label="Delete set" tabindex="-1">${TRASH_SVG}</button>`;
+}
+
 function setRowHtml(ex, exIdx, si, isCurrentEx) {
   const logged = ex.sets[si];
   const isEditing = !!logged && editingSet && editingSet.exIdx === exIdx && editingSet.setIdx === si;
   const isActive = isCurrentEx && !logged && si === ex.sets.length;
   const isPending = !logged && !isActive;
 
+  // Editing is a transient state and is not swipeable.
   if (isEditing) {
     return `
       <div class="set-row editing" data-set-idx="${si}">
@@ -241,13 +248,13 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
     `;
   }
 
+  // Every other row swipes left to reveal a trash button. Deleting a logged
+  // set removes it; deleting an unlogged (active/upcoming) slot trims the
+  // exercise's set count.
   if (logged) {
-    // Swipe the face left to reveal the trash button; tap the face to edit.
     return `
       <div class="set-row logged swipe-wrap" data-set-idx="${si}">
-        <button type="button" class="set-delete" data-act="delete-set" data-del-set="${exIdx},${si}" aria-label="Delete set" tabindex="-1">
-          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14M10 11v6M14 11v6"/></svg>
-        </button>
+        ${setDeleteBtnHtml(exIdx, si)}
         <div class="set-row-face" data-edit-set="${exIdx},${si}">
           <span class="lbl">${si + 1}</span>
           <span class="val">${fmtNum(logged.weight)} kg</span>
@@ -260,11 +267,14 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
 
   if (isPending) {
     return `
-      <div class="set-row pending">
-        <span class="lbl">${si + 1}</span>
-        <span class="val">– kg</span>
-        <span class="val">× –</span>
-        <span></span>
+      <div class="set-row pending swipe-wrap" data-set-idx="${si}">
+        ${setDeleteBtnHtml(exIdx, si)}
+        <div class="set-row-face">
+          <span class="lbl">${si + 1}</span>
+          <span class="val">– kg</span>
+          <span class="val">× –</span>
+          <span></span>
+        </div>
       </div>
     `;
   }
@@ -275,12 +285,15 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
   const wHasValue = wPrefill !== '' && !isNaN(parseFloat(wPrefill));
   const last = findLastSet(ex.name, si);
   return `
-    <div class="set-row active" data-set-idx="${si}">
-      <span class="lbl">${si + 1}</span>
-      <input type="tel" inputmode="decimal" class="set-w" value="${wHasValue ? wPrefill : ''}" placeholder="kg" autocomplete="off" maxlength="6">
-      ${repsStepperHtml(rPrefill)}
-      <button class="log-btn"${wHasValue ? '' : ' disabled'}>✓</button>
-      ${last ? `<button type="button" class="last-chip" data-fill-last data-w="${last.weight}" data-r="${last.reps}">Last: ${fmtNum(last.weight)} kg × ${last.reps} · tap to use</button>` : ''}
+    <div class="set-row active swipe-wrap" data-set-idx="${si}">
+      ${setDeleteBtnHtml(exIdx, si)}
+      <div class="set-row-face">
+        <span class="lbl">${si + 1}</span>
+        <input type="tel" inputmode="decimal" class="set-w" value="${wHasValue ? wPrefill : ''}" placeholder="kg" autocomplete="off" maxlength="6">
+        ${repsStepperHtml(rPrefill)}
+        <button class="log-btn"${wHasValue ? '' : ' disabled'}>✓</button>
+        ${last ? `<button type="button" class="last-chip" data-fill-last data-w="${last.weight}" data-r="${last.reps}">Last: ${fmtNum(last.weight)} kg × ${last.reps} · tap to use</button>` : ''}
+      </div>
     </div>
   `;
 }

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -133,14 +133,25 @@ function addSet(exIdx) {
   });
 }
 
-// Swipe-to-delete a logged set.
+// Set the number of set rows an exercise shows, by deriving extraSets from it.
+function setExerciseSlots(ex, n) {
+  n = Math.max(1, ex.sets.length, n);
+  ex.extraSets = n - ex.targetSets;
+}
+
+// Swipe-to-delete a set. A logged set is removed; an unlogged (active or
+// upcoming) slot just trims the exercise's planned set count by one.
 function removeSet(exIdx, si) {
   const a = state.active;
   if (!a) return;
   const ex = a.exercises[exIdx];
-  if (!ex || !ex.sets[si]) return;
-  ex.sets.splice(si, 1);
-  if (ex.extraSets > 0) ex.extraSets -= 1;
+  if (!ex) return;
+  const logged = si < ex.sets.length;
+  const slots = exerciseSlots(ex);
+  // Deleting an unlogged slot needs a spare slot, and we always keep >= 1 set.
+  if (!logged && slots <= Math.max(1, ex.sets.length)) return;
+  if (logged) ex.sets.splice(si, 1);
+  setExerciseSlots(ex, slots - 1);
   editingSet = null;
   // If the deletion leaves the exercise unfinished, keep the user focused on it.
   if (!exerciseIsResolved(ex)) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v24';
+const VERSION = 'v25';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',

--- a/styles.css
+++ b/styles.css
@@ -342,7 +342,18 @@
     display: flex; flex-direction: column; gap: 6px;
     margin-top: 9px; padding: 0;
   }
+  /* The row is a clipping wrapper; .set-row-face is the visible (sliding) layer.
+     The editing row has no face and lays itself out directly. */
   .set-row {
+    position: relative;
+    overflow: hidden;
+    border-radius: 11px;
+    box-sizing: border-box;
+    border: 0;
+    background: transparent;
+  }
+  .set-row-face,
+  .set-row.editing {
     display: grid;
     grid-template-columns: 26px 1fr 1fr 44px;
     gap: 9px;
@@ -350,7 +361,6 @@
     background: var(--bg);
     border-radius: 11px;
     padding: 8px 11px;
-    border: 0;
     box-sizing: border-box;
   }
   .set-row .lbl {
@@ -360,13 +370,12 @@
     font-size: 12px; font-weight: 700; font-variant-numeric: tabular-nums;
   }
   .set-row .val { font-size: 15px; font-weight: 600; font-variant-numeric: tabular-nums; }
-  .set-row.logged {
+  .set-row.logged .set-row-face {
     background: var(--success-dim);
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
-    transition: filter 0.12s ease;
   }
-  .set-row.logged:active { filter: brightness(0.96); }
+  .set-row.logged .set-row-face:active { filter: brightness(0.96); }
   .set-row.logged .lbl { background: var(--success); color: white; }
   .set-row.logged .val { color: var(--text); }
   .set-row.pending { opacity: 0.7; }
@@ -383,7 +392,7 @@
     color: var(--text-faint); font-size: 16px;
     pointer-events: none;
   }
-  .set-row.active { background: var(--accent-dim); padding: 7px 8px; }
+  .set-row.active .set-row-face { background: var(--accent-dim); padding: 7px 8px; }
   .set-row.active .lbl { background: var(--accent); color: white; }
   .set-row.editing {
     background: var(--accent-dim); padding: 7px 8px;
@@ -460,29 +469,18 @@
   }
   .add-set-btn:active { background: var(--bg); }
 
-  /* Swipe-to-reveal delete on a logged set row */
-  .set-row.swipe-wrap {
-    display: block; position: relative; overflow: hidden;
-    padding: 0; background: transparent; border-radius: 11px;
-    touch-action: pan-y;
-  }
+  /* Swipe-to-reveal delete — works on logged, active and upcoming set rows */
+  .set-row.swipe-wrap { touch-action: pan-y; }
   .set-row.swipe-wrap .set-row-face {
-    display: grid;
-    grid-template-columns: 26px 1fr 1fr 44px;
-    gap: 9px; align-items: center;
-    background: var(--success-dim);
-    border-radius: 11px; padding: 8px 11px;
-    box-sizing: border-box; position: relative; z-index: 1;
-    cursor: pointer; -webkit-tap-highlight-color: transparent;
+    position: relative; z-index: 1;
     transition: transform 0.22s cubic-bezier(.2,.7,.2,1);
     will-change: transform;
   }
-  .set-row.swipe-wrap .set-row-face:active { filter: brightness(0.96); }
   .set-row.swipe-wrap.revealed .set-row-face { transform: translateX(-72px); }
   .set-delete {
     position: absolute; top: 0; right: 0; bottom: 0; width: 72px;
     display: flex; align-items: center; justify-content: center;
-    border: 0; border-radius: 11px; background: var(--danger, #e5484d);
+    border: 0; border-radius: 11px; background: var(--danger);
     color: white; cursor: pointer; z-index: 0;
   }
 


### PR DESCRIPTION
Previously only logged sets were swipeable. Now every set row in the active exercise — logged, active, and upcoming — can be swiped left to reveal the trash button. Deleting a logged set removes it; deleting an unlogged slot trims the exercise's planned set count (extraSets can now go negative, with slots floored at the logged count and a minimum of one).

Refactor: the set row is now a clipping wrapper with a sliding .set-row-face layer carrying the visuals; the editing row stays non-swipeable. The weight input is excluded from initiating a swipe so its native touch behaviour is preserved.