### PR TITLE
Don't play the reorder slide on add/remove set or completion

### DIFF
--- a/js/workouts.js
+++ b/js/workouts.js
@@ -112,7 +112,9 @@ function addSet(exIdx) {
   a.activeExIdx = exIdx;
   expandedExIdx = null;
   editingSet = null;
-  renderRailReorder();
+  // In-place change — re-render without the reorder slide so the view stays put.
+  save();
+  render();
 
   requestAnimationFrame(() => {
     const card = document.querySelector(`.ex-rail-step.active[data-ex-idx="${exIdx}"]`);
@@ -158,7 +160,9 @@ function removeSet(exIdx, si) {
     if (lingeringExIdx === exIdx) lingeringExIdx = null;
     a.activeExIdx = exIdx;
   }
-  renderRailReorder();
+  // In-place change — re-render without the reorder slide so the view stays put.
+  save();
+  render();
 }
 
 /* ---------- Rail reorder animation (FLIP) ---------- */
@@ -393,10 +397,12 @@ function logCurrentSet(row) {
   }
 
   // Exercise complete — it lingers in place (editable). We do NOT auto-advance:
-  // the user selects the next exercise so they can tweak this one first.
+  // the user selects the next exercise so they can tweak this one first. The
+  // card stays where it is, so re-render without the reorder slide.
   lingeringExIdx = exIdx;
   state.active.activeExIdx = -1;
-  renderRailReorder();
+  save();
+  render();
 }
 
 function finishWorkout(opts = {}) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v25';
+const VERSION = 'v26';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',


### PR DESCRIPTION
Adding a set, deleting a set, and completing an exercise all keep the exercise in place, so the FLIP reorder animation was distracting (it looked like selecting a new exercise). These now re-render instantly. The slide is kept for the cases where exercises genuinely move: selecting a different active exercise and skipping.