### PR TITLE
Show per-set progression: +x when you beat your last completed set

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -66,6 +66,29 @@ function findLastSet(exerciseName, setIndex) {
   return null;
 }
 
+// The equivalent set (same index) from the most recent past workout in which
+// this exercise was fully completed — the baseline for progression badges.
+function lastCompletedSet(exerciseName, setIndex) {
+  for (let i = state.sessions.length - 1; i >= 0; i--) {
+    const ex = state.sessions[i].exercises.find(e => e.name === exerciseName);
+    if (!ex || ex.skipped) continue;
+    const target = ex.targetSets || 0;
+    if (ex.sets.length > 0 && ex.sets.length >= target && ex.sets[setIndex]) {
+      return ex.sets[setIndex];
+    }
+  }
+  return null;
+}
+
+// Weight/reps gained on a logged set versus the equivalent set last time this
+// exercise was completed. Returns null when there's no completed baseline.
+function setProgress(ex, setIndex, logged) {
+  if (!logged) return null;
+  const ref = lastCompletedSet(ex.name, setIndex);
+  if (!ref) return null;
+  return { weight: logged.weight - ref.weight, reps: logged.reps - ref.reps };
+}
+
 function weightPrefillFor(ex, si) {
   // Set 2+: take the weight from the previous set in this workout
   if (si > 0 && ex.sets[si - 1]) return ex.sets[si - 1].weight;

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -252,13 +252,17 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
   // set removes it; deleting an unlogged (active/upcoming) slot trims the
   // exercise's set count.
   if (logged) {
+    // Celebrate beating the same set from the last completed session.
+    const prog = setProgress(ex, si, logged);
+    const wPr = prog && prog.weight > 0 ? ` <span class="set-pr">+${fmtNum(prog.weight)}</span>` : '';
+    const rPr = prog && prog.reps > 0 ? ` <span class="set-pr">+${prog.reps}</span>` : '';
     return `
       <div class="set-row logged swipe-wrap" data-set-idx="${si}">
         ${setDeleteBtnHtml(exIdx, si)}
         <div class="set-row-face" data-edit-set="${exIdx},${si}">
           <span class="lbl">${si + 1}</span>
-          <span class="val">${fmtNum(logged.weight)} kg</span>
-          <span class="val">× ${logged.reps}</span>
+          <span class="val">${fmtNum(logged.weight)} kg${wPr}</span>
+          <span class="val">× ${logged.reps}${rPr}</span>
           <span class="set-check" aria-hidden="true">✓</span>
         </div>
       </div>

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v26';
+const VERSION = 'v27';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',

--- a/styles.css
+++ b/styles.css
@@ -370,6 +370,11 @@
     font-size: 12px; font-weight: 700; font-variant-numeric: tabular-nums;
   }
   .set-row .val { font-size: 15px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  /* Progression badge — gain vs the same set last time the exercise was completed */
+  .set-pr {
+    color: var(--success); font-size: 11px; font-weight: 700;
+    font-variant-numeric: tabular-nums; vertical-align: 1px;
+  }
   .set-row.logged .set-row-face {
     background: var(--success-dim);
     cursor: pointer;


### PR DESCRIPTION
Each logged set is compared against the same set index from the most recent past workout in which the exercise was fully completed. A small green +x appears next to the weight and/or reps when the new set exceeds that baseline. In-workout only; nothing shown when equal or lower.

Date stamps were already captured (session.date and per-set ts), so no data-model change was needed.