### PR TITLE
Unify progress stepper styling; drop numbers from week stepper circles

### DIFF
--- a/js/views/today.js
+++ b/js/views/today.js
@@ -56,7 +56,7 @@ function weekStepperHtml(selectedWeek) {
         const status = done ? 'completed' : active ? 'active' : 'planned';
         return `
           <button class="week-step ${classes}" data-select-week="${i}" aria-label="Week ${i + 1}, ${status}">
-            <span class="week-step-circle">${done ? '&#10003;' : i + 1}</span>
+            <span class="week-step-circle">${done ? '&#10003;' : ''}</span>
             <span class="week-step-label">Week ${i + 1}</span>
           </button>
         `;

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v27';
+const VERSION = 'v28';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',

--- a/styles.css
+++ b/styles.css
@@ -277,7 +277,7 @@
     font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; flex-shrink: 0;
   }
   .ex-rail-step.completed .ex-rail-circle { background: var(--success); border-color: var(--success); color: white; }
-  .ex-rail-step.active .ex-rail-circle { background: var(--accent); border-color: var(--accent); color: white; box-shadow: 0 0 0 5px var(--accent-dim); animation: wt-pulse-accent 2.6s ease-in-out infinite; }
+  .ex-rail-step.active .ex-rail-circle { background: transparent; border-color: var(--accent); color: var(--accent); box-shadow: 0 0 0 5px var(--accent-dim); animation: wt-pulse-accent 2.6s ease-in-out infinite; }
   .ex-rail-step.skipped .ex-rail-circle { background: var(--warn); border-color: var(--warn); color: white; }
   .ex-rail-body { min-width: 0; padding-bottom: 18px; }
   .ex-rail-step:last-child .ex-rail-body { padding-bottom: 0; }
@@ -963,11 +963,15 @@
     font-weight: 700;
     font-variant-numeric: tabular-nums;
   }
-  .week-step.completed .week-step-circle,
-  .week-step.active .week-step-circle {
+  .week-step.completed .week-step-circle {
     background: var(--success);
     border-color: var(--success);
     color: white;
+  }
+  .week-step.active .week-step-circle {
+    background: transparent;
+    border: 2px solid var(--accent);
+    color: var(--accent);
   }
   .week-step.selected .week-step-circle {
     box-shadow: 0 0 0 4px var(--accent-dim);
@@ -1185,11 +1189,15 @@
     cursor: pointer;
     font-variant-numeric: tabular-nums;
   }
-  .day-step.completed .day-step-circle,
-  .day-step.active .day-step-circle {
+  .day-step.completed .day-step-circle {
     background: var(--success);
     border-color: var(--success);
     color: white;
+  }
+  .day-step.active .day-step-circle {
+    background: transparent;
+    border: 2px solid var(--accent);
+    color: var(--accent);
   }
   .day-step.expanded .day-step-circle {
     box-shadow: 0 0 0 4px var(--accent-dim);
@@ -1274,8 +1282,9 @@
     border-color: var(--success);
   }
   .exercise-step.active .exercise-step-dot {
-    background: var(--success);
-    border-color: var(--success);
+    background: transparent;
+    border: 2px solid var(--accent);
+    color: var(--accent);
   }
   .exercise-step.skipped .exercise-step-dot {
     background: var(--warn);


### PR DESCRIPTION
- Week stepper circles no longer show the week number (the Week N label beneath already identifies them); completed weeks still show a tick.
- All progress steppers (week, day, exercise, in-workout rail) now share one scheme: completed = solid green with white tick; active = blue outline with no fill; upcoming = greyed out. Previously active rendered as solid green on the Today steppers and solid blue on the workout rail.
- The in-workout active circle keeps its pulsing ring.