### PR TITLE
Active progress step: green outline with white fill

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v28';
+const VERSION = 'v29';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',

--- a/styles.css
+++ b/styles.css
@@ -277,7 +277,7 @@
     font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; flex-shrink: 0;
   }
   .ex-rail-step.completed .ex-rail-circle { background: var(--success); border-color: var(--success); color: white; }
-  .ex-rail-step.active .ex-rail-circle { background: transparent; border-color: var(--accent); color: var(--accent); box-shadow: 0 0 0 5px var(--accent-dim); animation: wt-pulse-accent 2.6s ease-in-out infinite; }
+  .ex-rail-step.active .ex-rail-circle { background: white; border-color: var(--success); color: var(--success); box-shadow: 0 0 0 5px var(--accent-dim); animation: wt-pulse-accent 2.6s ease-in-out infinite; }
   .ex-rail-step.skipped .ex-rail-circle { background: var(--warn); border-color: var(--warn); color: white; }
   .ex-rail-body { min-width: 0; padding-bottom: 18px; }
   .ex-rail-step:last-child .ex-rail-body { padding-bottom: 0; }
@@ -969,9 +969,9 @@
     color: white;
   }
   .week-step.active .week-step-circle {
-    background: transparent;
-    border: 2px solid var(--accent);
-    color: var(--accent);
+    background: white;
+    border: 2px solid var(--success);
+    color: var(--success);
   }
   .week-step.selected .week-step-circle {
     box-shadow: 0 0 0 4px var(--accent-dim);
@@ -1195,9 +1195,9 @@
     color: white;
   }
   .day-step.active .day-step-circle {
-    background: transparent;
-    border: 2px solid var(--accent);
-    color: var(--accent);
+    background: white;
+    border: 2px solid var(--success);
+    color: var(--success);
   }
   .day-step.expanded .day-step-circle {
     box-shadow: 0 0 0 4px var(--accent-dim);
@@ -1282,9 +1282,9 @@
     border-color: var(--success);
   }
   .exercise-step.active .exercise-step-dot {
-    background: transparent;
-    border: 2px solid var(--accent);
-    color: var(--accent);
+    background: white;
+    border: 2px solid var(--success);
+    color: var(--success);
   }
   .exercise-step.skipped .exercise-step-dot {
     background: var(--warn);


### PR DESCRIPTION
Change the active state across all four progress steppers (week, day, exercise, in-workout rail) from a blue outline on no fill to a green outline with a white fill. The in-workout rail keeps its pulsing ring.