### PR TITLE
Add, remove, and drag-to-reorder exercises mid-workout, saved to the …

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -12,11 +12,102 @@ function bindGlobalEvents() {
   document.addEventListener('touchmove', onTouchMove, { passive: false });
   document.addEventListener('touchend', onTouchEnd);
   document.addEventListener('touchcancel', onTouchEnd);
+  document.addEventListener('pointerdown', onDragHandleDown);
 }
 
-/* ---------- Swipe-to-reveal delete on logged set rows ---------- */
+/* ---------- Drag-to-reorder upcoming exercises ----------
+   Press the dots handle on an upcoming exercise row and drag vertically.
+   The dragged row follows the pointer; siblings shift out of the way. On
+   drop, the new order is committed to the session and the program. */
+let dragEx = null;
+
+function onDragHandleDown(e) {
+  if (e.button != null && e.button !== 0) return;
+  const handle = e.target.closest && e.target.closest('.drag-handle');
+  if (!handle) return;
+  const row = handle.closest('.ex-rail-step');
+  const rail = row && row.closest('.ex-rail');
+  if (!row || !rail) return;
+  const rows = Array.from(rail.querySelectorAll('.ex-rail-step.upcoming'));
+  const fromPos = rows.indexOf(row);
+  if (rows.length < 2 || fromPos < 0) return;
+  e.preventDefault();
+  closeAllReveals(null);
+  dragEx = {
+    pointerId: e.pointerId,
+    handle, row, rows,
+    rects: rows.map(r => r.getBoundingClientRect()),
+    startY: e.clientY,
+    fromPos,
+    curPos: fromPos,
+    moved: false
+  };
+  rows.forEach(r => r.classList.add(r === row ? 'dragging' : 'drag-sib'));
+  try { handle.setPointerCapture(e.pointerId); } catch (_) {}
+  document.addEventListener('pointermove', onDragMove);
+  document.addEventListener('pointerup', onDragEnd);
+  document.addEventListener('pointercancel', onDragEnd);
+}
+
+function onDragMove(e) {
+  if (!dragEx || e.pointerId !== dragEx.pointerId) return;
+  const d = dragEx;
+  const dy = e.clientY - d.startY;
+  if (Math.abs(dy) > 4) d.moved = true;
+  d.row.style.transform = `translateY(${dy}px)`;
+
+  const dragRect = d.rects[d.fromPos];
+  // A row is passed once the dragged row's leading edge crosses its center
+  // (i.e. overlaps it by half) — the standard sortable feel.
+  const top = dragRect.top + dy;
+  const bottom = dragRect.bottom + dy;
+  let pos = d.fromPos;
+  d.rows.forEach((r, i) => {
+    if (i === d.fromPos) return;
+    const center = d.rects[i].top + d.rects[i].height / 2;
+    if (i < d.fromPos && top < center) pos--;
+    if (i > d.fromPos && bottom > center) pos++;
+  });
+  d.curPos = pos;
+
+  // Siblings shift by the dragged row's height to open/close the gap.
+  d.rows.forEach((r, i) => {
+    if (i === d.fromPos) return;
+    const without = i < d.fromPos ? i : i - 1; // position with dragged removed
+    const newPos = without >= pos ? without + 1 : without;
+    r.style.transform = newPos !== i ? `translateY(${(newPos - i) * dragRect.height}px)` : '';
+  });
+}
+
+function onDragEnd(e) {
+  if (!dragEx || e.pointerId !== dragEx.pointerId) return;
+  // Fold the release position into the final slot calculation.
+  if (e.type === 'pointerup' && typeof e.clientY === 'number') onDragMove(e);
+  const d = dragEx;
+  dragEx = null;
+  document.removeEventListener('pointermove', onDragMove);
+  document.removeEventListener('pointerup', onDragEnd);
+  document.removeEventListener('pointercancel', onDragEnd);
+  // A drag must not double as a tap on the row underneath.
+  suppressNextClick = true;
+  setTimeout(() => { suppressNextClick = false; }, 400);
+
+  const commit = d.moved && e.type !== 'pointercancel' && d.curPos !== d.fromPos;
+  const slotIdxs = d.rows.map(r => +r.dataset.exIdx);
+  const seq = d.rows.map((_, i) => i).filter(i => i !== d.fromPos);
+  seq.splice(d.curPos, 0, d.fromPos);
+  const orderedExIdxs = seq.map(i => +d.rows[i].dataset.exIdx);
+
+  d.rows.forEach(r => {
+    r.style.transform = '';
+    r.classList.remove('dragging', 'drag-sib');
+  });
+  if (commit) reorderWorkoutExercises(slotIdxs, orderedExIdxs);
+}
+
+/* ---------- Swipe-to-reveal delete on set rows and exercise rows ---------- */
 function closeAllReveals(except) {
-  document.querySelectorAll('.set-row.revealed').forEach(el => {
+  document.querySelectorAll('.swipe-wrap.revealed').forEach(el => {
     if (el !== except) el.classList.remove('revealed');
   });
 }
@@ -25,11 +116,13 @@ function onTouchStart(e) {
   // A fresh touch is deliberate intent — never suppress its click.
   suppressNextClick = false;
   if (e.touches.length !== 1) { swipe = null; return; }
-  const wrap = e.target.closest && e.target.closest('.set-row.swipe-wrap');
-  // Don't begin a swipe from the trash button or from a text input (so the
+  // Innermost swipeable wins: a set row inside an exercise card swipes the
+  // set; touching the card elsewhere swipes the whole exercise.
+  const wrap = e.target.closest && e.target.closest('.swipe-wrap');
+  // Don't begin a swipe from a trash button or from a text input (so the
   // active row's weight field keeps its native touch behaviour).
-  if (!wrap || (e.target.closest && e.target.closest('.set-delete, input'))) { swipe = null; return; }
-  const face = wrap.querySelector('.set-row-face');
+  if (!wrap || (e.target.closest && e.target.closest('.set-delete, .ex-delete, .drag-handle, input'))) { swipe = null; return; }
+  const face = wrap.querySelector(':scope > .swipe-face');
   if (!face) { swipe = null; return; }
   const t = e.touches[0];
   swipe = {
@@ -84,6 +177,8 @@ function onFocusIn(e) {
 function onClick(e) {
   // A just-finished swipe shouldn't trigger a tap action.
   if (suppressNextClick) { suppressNextClick = false; return; }
+  // The reorder handle is drag-only — a stray tap on it must not select the row.
+  if (e.target.closest && e.target.closest('.drag-handle')) return;
 
   // Tap the revealed trash button to delete that set.
   const delBtn = e.target.closest && e.target.closest('[data-act="delete-set"]');
@@ -92,8 +187,16 @@ function onClick(e) {
     removeSet(exIdx, si);
     return;
   }
-  // With a set swiped open, the next tap anywhere just closes it.
-  if (document.querySelector('.set-row.revealed')) {
+  // Tap the revealed trash button on an exercise to remove it from the
+  // workout and from the program going forward.
+  const exDelBtn = e.target.closest && e.target.closest('[data-act="delete-ex"]');
+  if (exDelBtn) {
+    closeAllReveals(null);
+    removeExerciseFromWorkout(+exDelBtn.dataset.exIdx);
+    return;
+  }
+  // With a row swiped open, the next tap anywhere just closes it.
+  if (document.querySelector('.swipe-wrap.revealed')) {
     closeAllReveals(null);
     return;
   }
@@ -352,6 +455,28 @@ function onClick(e) {
     addSet(+addSetBtn.dataset.exIdx);
     return;
   }
+  // "+ Add Exercise" — open the inline picker on the Workout tab
+  if (e.target.dataset.act === 'add-ex-workout') {
+    addingExercise = true;
+    render();
+    requestAnimationFrame(() => {
+      const input = document.getElementById('new-workout-ex');
+      if (input) input.focus();
+    });
+    return;
+  }
+  if (e.target.dataset.act === 'confirm-add-ex') {
+    const input = document.getElementById('new-workout-ex');
+    const name = input ? input.value : '';
+    if (withUnloggedSetGuard(() => addExerciseToWorkout(name), 'Add without saving set')) return;
+    addExerciseToWorkout(name);
+    return;
+  }
+  if (e.target.dataset.act === 'cancel-add-ex') {
+    addingExercise = false;
+    render();
+    return;
+  }
   // Tap an outstanding exercise to make it the active one
   const selectActive = e.target.closest && e.target.closest('[data-select-active]');
   if (selectActive) {
@@ -491,6 +616,13 @@ function onKeydown(e) {
       addLibraryExercise();
       return;
     }
+    if (e.target.id === 'new-workout-ex') {
+      e.preventDefault();
+      const name = e.target.value;
+      if (withUnloggedSetGuard(() => addExerciseToWorkout(name), 'Add without saving set')) return;
+      addExerciseToWorkout(name);
+      return;
+    }
     const libraryEditRow = e.target.closest && e.target.closest('.library-row.editing');
     if (libraryEditRow) {
       e.preventDefault();
@@ -513,6 +645,11 @@ function onKeydown(e) {
   if (e.key === 'Escape') {
     if (editingSet) {
       editingSet = null;
+      render();
+      return;
+    }
+    if (addingExercise) {
+      addingExercise = false;
       render();
       return;
     }

--- a/js/state.js
+++ b/js/state.js
@@ -167,6 +167,7 @@ let editingSet = null;  // { exIdx, setIdx } when a logged set is being edited
 let expandedExIdx = null;  // index of a completed exercise expanded for editing in the Completed section
 let lingeringExIdx = null; // a just-completed exercise still shown in place, awaiting the next action
 let completedCollapsed = true; // the Completed section starts collapsed
+let addingExercise = false; // the inline "+ Add Exercise" form on the Workout tab is open
 let selectedWeekIndex = null; // UI-only selected week on Today
 let expandedDayKey = null;    // UI-only expanded Today day, formatted as "week:day"
 let exerciseLibrarySearch = '';

--- a/js/views/today.js
+++ b/js/views/today.js
@@ -265,15 +265,21 @@ function exerciseStepperHtml(day, weekIndex, dayIndex, session) {
     state.active.dayIndex === dayIndex
       ? state.active
       : null;
-  const firstOpen = activeWorkout
-    ? activeWorkout.exercises.findIndex(e => !exerciseIsResolved(e))
+  // Exercises removed mid-workout stay in the active session (to keep their
+  // logged sets) but no longer exist in the template, so line the template up
+  // against the non-removed entries only.
+  const liveExercises = activeWorkout
+    ? activeWorkout.exercises.filter(e => !e.removed)
+    : null;
+  const firstOpen = liveExercises
+    ? liveExercises.findIndex(e => !exerciseIsResolved(e))
     : -1;
   const usedSessionExercises = new Set();
 
   return `
     <div class="exercise-stepper">
       ${day.exercises.map((planned, i) => {
-        const activeEx = activeWorkout ? activeWorkout.exercises[i] : null;
+        const activeEx = liveExercises ? liveExercises[i] : null;
         const sessionEx = activeEx ? null : matchingSessionExercise(session, planned, i, usedSessionExercises);
         const source = activeEx || sessionEx || planned;
         const targetSets = source.targetSets || planned.sets;

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -27,10 +27,17 @@ Views.workout = function() {
     return upNextStepHtml(a.exercises[i], i);
   }).join('');
 
-  const topCard = topHtml ? `<div class="card"><div class="ex-rail">${topHtml}</div></div>` : '';
+  const topCard = `
+    <div class="card">
+      ${topHtml ? `<div class="ex-rail">${topHtml}</div>` : ''}
+      ${addExerciseRowHtml()}
+    </div>`;
   const completedCard = completedSectionHtml(a, linger);
 
   return `
+    <datalist id="exercise-options">
+      ${exerciseNameSuggestions().map(n => `<option value="${esc(n)}">`).join('')}
+    </datalist>
     <div class="workout-top">
       <div style="margin-bottom:13px;">
         <div class="section-label" style="margin-bottom:3px;">Week ${a.weekIndex + 1}</div>
@@ -73,7 +80,9 @@ function activeStepHtml(ex, i) {
   return `
     <div class="ex-rail-step active" data-ex-idx="${i}">
       <div class="ex-rail-node"><span class="ex-rail-circle"></span></div>
-      <div class="ex-rail-body">
+      <div class="ex-rail-body swipe-wrap">
+        ${exDeleteBtnHtml(i)}
+        <div class="ex-body-face swipe-face">
         <div class="dense-line">
           <div style="min-width:0;">
             <div class="rail-eyebrow active">Active</div>
@@ -89,6 +98,7 @@ function activeStepHtml(ex, i) {
           ${Array.from({length: exerciseSlots(ex)}, (_, si) => setRowHtml(ex, i, si, true)).join('')}
         </div>
         ${addSetBtnHtml(i)}
+        </div>
       </div>
     </div>
   `;
@@ -97,6 +107,32 @@ function activeStepHtml(ex, i) {
 // "+ Add set" — appends one more loggable set beyond the allocated target.
 function addSetBtnHtml(exIdx) {
   return `<button type="button" class="add-set-btn" data-act="add-set" data-ex-idx="${exIdx}">+ Add set</button>`;
+}
+
+// "+ Add Exercise" at the bottom of the outstanding list — opens an inline
+// picker using the same exercise-library dropdown as Edit Program. The new
+// exercise is saved to the program going forward.
+function addExerciseRowHtml() {
+  if (!addingExercise) {
+    return `<button type="button" class="add-set-btn add-ex-btn" data-act="add-ex-workout">+ Add Exercise</button>`;
+  }
+  return `
+    <div class="add-ex-form">
+      <input type="text" id="new-workout-ex" list="exercise-options" placeholder="Exercise name" autocomplete="off">
+      <button type="button" class="btn small" data-act="confirm-add-ex">Add</button>
+      <button type="button" class="btn icon" data-act="cancel-add-ex" title="Cancel">×</button>
+    </div>
+  `;
+}
+
+function exDeleteBtnHtml(exIdx) {
+  return `<button type="button" class="ex-delete" data-act="delete-ex" data-ex-idx="${exIdx}" aria-label="Remove exercise" tabindex="-1">${TRASH_SVG}</button>`;
+}
+
+const DRAG_SVG = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><circle cx="5" cy="3" r="1.5"/><circle cx="11" cy="3" r="1.5"/><circle cx="5" cy="8" r="1.5"/><circle cx="11" cy="8" r="1.5"/><circle cx="5" cy="13" r="1.5"/><circle cx="11" cy="13" r="1.5"/></svg>';
+
+function dragHandleHtml() {
+  return `<button type="button" class="drag-handle" aria-label="Reorder exercise" tabindex="-1">${DRAG_SVG}</button>`;
 }
 
 // An outstanding exercise that isn't active yet — tap to make it active. Blank circle.
@@ -112,12 +148,15 @@ function upNextStepHtml(ex, i) {
   return `
     <div class="ex-rail-step upcoming dense-collapsed" data-ex-idx="${i}">
       <div class="ex-rail-node"><span class="ex-rail-circle"></span></div>
-      <div class="ex-rail-body selectable" data-select-active="${i}">
-        <div class="dense-line">
-          <div class="ex-rail-name">${name}</div>
-          ${badge}
+      <div class="ex-rail-body selectable swipe-wrap" data-select-active="${i}">
+        ${exDeleteBtnHtml(i)}
+        <div class="ex-body-face swipe-face">
+          <div class="dense-line">
+            <div class="ex-rail-name">${name}</div>
+            <span class="row" style="gap:2px;">${badge}${dragHandleHtml()}</span>
+          </div>
+          <div class="dense-summary">${summary}</div>
         </div>
-        <div class="dense-summary">${summary}</div>
       </div>
     </div>
   `;
@@ -130,7 +169,9 @@ function lingerStepHtml(ex, i) {
   return `
     <div class="ex-rail-step completed expanded linger" data-ex-idx="${i}">
       <div class="ex-rail-node"><span class="ex-rail-circle">✓</span></div>
-      <div class="ex-rail-body">
+      <div class="ex-rail-body swipe-wrap">
+        ${exDeleteBtnHtml(i)}
+        <div class="ex-body-face swipe-face">
         <div class="dense-line">
           <div style="min-width:0;">
             <div class="rail-eyebrow done">Completed</div>
@@ -143,6 +184,7 @@ function lingerStepHtml(ex, i) {
           ${ex.sets.map((s, si) => setRowHtml(ex, i, si, false)).join('')}
         </div>
         ${addSetBtnHtml(i)}
+        </div>
       </div>
     </div>
   `;
@@ -176,19 +218,27 @@ function completedSectionHtml(a, linger) {
 // A row inside the Completed section — tap to expand and edit its logged sets.
 function completedRowHtml(ex, i) {
   const skipped = !!ex.skipped;
+  const removed = !!ex.removed;
   const name = esc(ex.name);
   const circle = skipped ? '–' : '✓';
-  const badge = skipped
-    ? `<span class="badge warn">${ex.sets.length ? 'Skipped rest' : 'Skipped'}</span>`
-    : `<span class="badge success">${ex.sets.length}/${exerciseSlots(ex)} ✓</span>`;
+  const badge = removed
+    ? `<span class="badge warn">Removed</span>`
+    : skipped
+      ? `<span class="badge warn">${ex.sets.length ? 'Skipped rest' : 'Skipped'}</span>`
+      : `<span class="badge success">${ex.sets.length}/${exerciseSlots(ex)} ✓</span>`;
   const editable = ex.sets.length > 0;
   const expanded = editable && i === expandedExIdx;
+  // An already-removed exercise can't be swiped away again.
+  const wrapOpen = removed
+    ? (extra) => `<div class="ex-rail-body${extra.cls || ''}"${extra.attrs || ''}>`
+    : (extra) => `<div class="ex-rail-body swipe-wrap${extra.cls || ''}"${extra.attrs || ''}>${exDeleteBtnHtml(i)}<div class="ex-body-face swipe-face">`;
+  const wrapClose = removed ? '</div>' : '</div></div>';
 
   if (expanded) {
     return `
       <div class="ex-rail-step ${skipped ? 'skipped' : 'completed'} expanded" data-ex-idx="${i}">
         <div class="ex-rail-node"><span class="ex-rail-circle">${circle}</span></div>
-        <div class="ex-rail-body">
+        ${wrapOpen({})}
           <div class="dense-line edit-toggle" data-toggle-done="${i}">
             <div class="ex-rail-name">${name}</div>
             ${badge}
@@ -197,26 +247,28 @@ function completedRowHtml(ex, i) {
           <div class="sets-modern">
             ${ex.sets.map((s, si) => setRowHtml(ex, i, si, false)).join('')}
           </div>
-          ${addSetBtnHtml(i)}
-        </div>
+          ${removed ? '' : addSetBtnHtml(i)}
+        ${wrapClose}
       </div>
     `;
   }
 
-  const summary = skipped
-    ? (ex.sets.length ? `${esc(sessionExerciseSetSummary(ex))} · skipped rest` : 'Skipped this session')
-    : ex.sets.map(s => `${fmtNum(s.weight)}×${s.reps}`).join(' · ');
+  const summary = removed
+    ? (ex.sets.length ? `${esc(sessionExerciseSetSummary(ex))} · removed from program` : 'Removed from program')
+    : skipped
+      ? (ex.sets.length ? `${esc(sessionExerciseSetSummary(ex))} · skipped rest` : 'Skipped this session')
+      : ex.sets.map(s => `${fmtNum(s.weight)}×${s.reps}`).join(' · ');
   const editAttr = editable ? ` data-toggle-done="${i}"` : '';
   return `
     <div class="ex-rail-step ${skipped ? 'skipped' : 'completed'} dense-collapsed" data-ex-idx="${i}">
       <div class="ex-rail-node"><span class="ex-rail-circle">${circle}</span></div>
-      <div class="ex-rail-body${editable ? ' editable' : ''}"${editAttr}>
+      ${wrapOpen({ cls: editable ? ' editable' : '', attrs: editAttr })}
         <div class="dense-line">
           <div class="ex-rail-name">${name}</div>
           ${badge}
         </div>
         <div class="dense-summary">${summary}${editable ? ' · tap to edit' : ''}</div>
-      </div>
+      ${wrapClose}
     </div>
   `;
 }
@@ -259,7 +311,7 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
     return `
       <div class="set-row logged swipe-wrap" data-set-idx="${si}">
         ${setDeleteBtnHtml(exIdx, si)}
-        <div class="set-row-face" data-edit-set="${exIdx},${si}">
+        <div class="set-row-face swipe-face" data-edit-set="${exIdx},${si}">
           <span class="lbl">${si + 1}</span>
           <span class="val">${fmtNum(logged.weight)} kg${wPr}</span>
           <span class="val">× ${logged.reps}${rPr}</span>
@@ -273,7 +325,7 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
     return `
       <div class="set-row pending swipe-wrap" data-set-idx="${si}">
         ${setDeleteBtnHtml(exIdx, si)}
-        <div class="set-row-face">
+        <div class="set-row-face swipe-face">
           <span class="lbl">${si + 1}</span>
           <span class="val">– kg</span>
           <span class="val">× –</span>
@@ -291,7 +343,7 @@ function setRowHtml(ex, exIdx, si, isCurrentEx) {
   return `
     <div class="set-row active swipe-wrap" data-set-idx="${si}">
       ${setDeleteBtnHtml(exIdx, si)}
-      <div class="set-row-face">
+      <div class="set-row-face swipe-face">
         <span class="lbl">${si + 1}</span>
         <input type="tel" inputmode="decimal" class="set-w" value="${wHasValue ? wPrefill : ''}" placeholder="kg" autocomplete="off" maxlength="6">
         ${repsStepperHtml(rPrefill)}

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -9,6 +9,7 @@ function startWorkout(dayIndex) {
   expandedExIdx = null;
   lingeringExIdx = null;
   completedCollapsed = true;
+  addingExercise = false;
   selectedWeekIndex = state.currentRun.weekIndex || 0;
   expandedDayKey = dayKey(selectedWeekIndex, dayIndex);
   state.active = {
@@ -133,6 +134,204 @@ function addSet(exIdx) {
     const w = row.querySelector('.set-w');
     if (w) w.focus();
   });
+}
+
+/* ---------- Mid-workout add / remove exercise ---------- */
+// The template day this active workout was started from.
+function templateDayForActive() {
+  const a = state.active;
+  if (!a || !state.program) return null;
+  return state.program.template[a.dayIndex] || null;
+}
+
+// a.exercises minus removed-but-retained entries lines up 1:1 with the
+// template day's exercise list, so the template index for an active-workout
+// exercise is its position among the non-removed entries.
+function templateIdxForExercise(exIdx) {
+  const a = state.active;
+  let n = 0;
+  for (let i = 0; i < exIdx; i++) if (!a.exercises[i].removed) n++;
+  return n;
+}
+
+// Persist state.program.template into the matching library record so
+// mid-workout program edits survive program switches.
+function syncActiveProgramRecord() {
+  if (!state.program || !state.activeProgramId) return;
+  state.programLibrary = normalizeProgramLibrary(state);
+  const rec = state.programLibrary.find(p => p.id === state.activeProgramId);
+  if (!rec) return;
+  rec.template = structuredClone(state.program.template);
+  rec.updatedAt = Date.now();
+}
+
+// "+ Add Exercise" on the Workout tab — appends to today's workout AND to the
+// program template (1 set × 0 reps placeholder), then makes it active.
+function addExerciseToWorkout(name) {
+  const a = state.active;
+  if (!a) return;
+  const clean = String(name || '').trim();
+  if (!clean) {
+    showModal({
+      title: 'Name required',
+      body: 'Enter an exercise name first.',
+      confirmText: 'OK',
+      hideCancel: true,
+      onConfirm: closeModal
+    });
+    return;
+  }
+  const entry = ensureExerciseInLibrary(clean);
+  const finalName = entry ? entry.name : clean;
+  const day = templateDayForActive();
+  if (day) {
+    day.exercises.push({ name: finalName, sets: 1, reps: 0 });
+    syncActiveProgramRecord();
+  }
+  a.exercises.push({
+    name: finalName,
+    targetSets: 1,
+    targetReps: 0,
+    sets: [],
+    skipped: false,
+    addedMidWorkout: true
+  });
+  const idx = a.exercises.length - 1;
+  reclaimExtraSlots(idx);
+  maybeFlushLinger(idx);
+  a.activeExIdx = idx;
+  addingExercise = false;
+  editingSet = null;
+  renderRailReorder();
+  requestAnimationFrame(() => {
+    const card = document.querySelector(`.ex-rail-step.active[data-ex-idx="${idx}"]`);
+    if (card) card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  });
+}
+
+// Swipe-to-delete an exercise — removes it from the program going forward.
+// Sets already logged this session stay saved: the exercise is retained in the
+// session (marked removed) and files into the Completed section.
+function removeExerciseFromWorkout(exIdx) {
+  const a = state.active;
+  if (!a) return;
+  const ex = a.exercises[exIdx];
+  if (!ex || ex.removed) return;
+  if (a.exercises.filter(e => !e.removed).length <= 1) {
+    showModal({
+      title: 'Cannot remove',
+      body: 'A workout needs at least one exercise.',
+      confirmText: 'OK',
+      hideCancel: true,
+      onConfirm: closeModal
+    });
+    return;
+  }
+  const hasSets = ex.sets.length > 0;
+  showModal({
+    title: 'Remove exercise?',
+    body: hasSets
+      ? `${ex.name} will be removed from ${a.dayName} going forward. The ${ex.sets.length} set${ex.sets.length === 1 ? '' : 's'} you logged today stay${ex.sets.length === 1 ? 's' : ''} saved.`
+      : `${ex.name} will be removed from this workout and from ${a.dayName} going forward.`,
+    confirmText: 'Remove',
+    danger: true,
+    onConfirm: () => {
+      closeModal();
+      // Remove from the program template (and saved program) first, while the
+      // non-removed entries still line up with the template.
+      const day = templateDayForActive();
+      if (day) {
+        let ti = templateIdxForExercise(exIdx);
+        if (!day.exercises[ti] || day.exercises[ti].name !== ex.name) {
+          ti = day.exercises.findIndex(e => e.name === ex.name);
+        }
+        if (ti >= 0) day.exercises.splice(ti, 1);
+        syncActiveProgramRecord();
+      }
+      if (hasSets) {
+        // Keep the logged sets in the session: retain the exercise, trim its
+        // slots to what was logged so it resolves into the Completed section.
+        ex.removed = true;
+        setExerciseSlots(ex, ex.sets.length);
+        if (a.activeExIdx === exIdx) a.activeExIdx = -1;
+        if (lingeringExIdx === exIdx) lingeringExIdx = null;
+      } else {
+        a.exercises.splice(exIdx, 1);
+        if (a.activeExIdx != null && a.activeExIdx >= 0) {
+          a.activeExIdx = a.activeExIdx === exIdx ? -1 : a.activeExIdx > exIdx ? a.activeExIdx - 1 : a.activeExIdx;
+        }
+        const shift = v => (v == null || v === exIdx) ? null : v > exIdx ? v - 1 : v;
+        lingeringExIdx = shift(lingeringExIdx);
+        expandedExIdx = shift(expandedExIdx);
+        if (editingSet) {
+          if (editingSet.exIdx === exIdx) editingSet = null;
+          else if (editingSet.exIdx > exIdx) editingSet.exIdx--;
+        }
+      }
+      renderRailReorder();
+    }
+  });
+}
+
+// Drag-to-reorder the upcoming exercises. slotIdxs are the array positions
+// being permuted (ascending); orderedExIdxs is the same set of indices in
+// their new visual order. The program template (and the saved program in the
+// library) get the same new order going forward.
+function reorderWorkoutExercises(slotIdxs, orderedExIdxs) {
+  const a = state.active;
+  if (!a || slotIdxs.length !== orderedExIdxs.length) return;
+  const day = templateDayForActive();
+  // Resolve template positions/items BEFORE mutating the session array.
+  const tplSlots = day ? slotIdxs.map(i => templateIdxForExercise(i)) : [];
+  const tplItems = day ? orderedExIdxs.map(i => {
+    let ti = templateIdxForExercise(i);
+    const ex = a.exercises[i];
+    if (!day.exercises[ti] || day.exercises[ti].name !== ex.name) {
+      ti = day.exercises.findIndex(t => t.name === ex.name);
+    }
+    return day.exercises[ti] || null;
+  }) : [];
+  const exItems = orderedExIdxs.map(i => a.exercises[i]);
+  slotIdxs.forEach((slot, k) => { a.exercises[slot] = exItems[k]; });
+  if (day && tplItems.length && tplItems.every(Boolean)) {
+    tplSlots.forEach((slot, k) => { day.exercises[slot] = tplItems[k]; });
+    syncActiveProgramRecord();
+  }
+  save();
+  render();
+}
+
+// Exercises added mid-workout enter the template as a 1×0 placeholder; once
+// the workout is saved, record what was actually performed.
+function persistAddedExerciseTargets(a) {
+  const day = templateDayForActive();
+  if (!day) return;
+  let changed = false;
+  a.exercises.forEach((ex, i) => {
+    if (!ex.addedMidWorkout || ex.removed || !ex.sets.length) return;
+    let ti = templateIdxForExercise(i);
+    if (!day.exercises[ti] || day.exercises[ti].name !== ex.name) {
+      ti = day.exercises.findIndex(e => e.name === ex.name);
+    }
+    const tpl = day.exercises[ti];
+    if (!tpl) return;
+    tpl.sets = ex.sets.length;
+    tpl.reps = modeReps(ex.sets);
+    changed = true;
+  });
+  if (changed) syncActiveProgramRecord();
+}
+
+// The most common rep count across logged sets (latest wins a tie).
+function modeReps(sets) {
+  const counts = new Map();
+  let best = sets[0] ? sets[0].reps : 0;
+  sets.forEach(s => {
+    const n = (counts.get(s.reps) || 0) + 1;
+    counts.set(s.reps, n);
+    if (n >= (counts.get(best) || 0)) best = s.reps;
+  });
+  return best;
 }
 
 // Set the number of set rows an exercise shows, by deriving extraSets from it.
@@ -408,6 +607,7 @@ function logCurrentSet(row) {
 function finishWorkout(opts = {}) {
   const a = state.active;
   if (!a) return;
+  persistAddedExerciseTargets(a);
   const exsWithSets = a.exercises.filter(e => e.sets.length > 0);
   const sessionExercises = a.exercises.filter(e => e.sets.length > 0 || e.skipped);
   if (!sessionExercises.length) {
@@ -433,6 +633,7 @@ function finishWorkout(opts = {}) {
       sets: e.sets,
       skipped: !!e.skipped,
       skippedAt: e.skippedAt || null,
+      removed: !!e.removed,
       targetSets: e.targetSets,
       targetReps: e.targetReps
     }))
@@ -533,6 +734,7 @@ function finishWorkout(opts = {}) {
   expandedExIdx = null;
   lingeringExIdx = null;
   completedCollapsed = true;
+  addingExercise = false;
   save();
   render();
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v29';
+const VERSION = 'v30';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',

--- a/styles.css
+++ b/styles.css
@@ -311,7 +311,8 @@
   .ex-rail-body.selectable:active { opacity: 0.7; }
 
   /* Just-completed exercise lingering in place before it files away */
-  .ex-rail-step.linger .ex-rail-body {
+  .ex-rail-step.linger .ex-rail-body,
+  .ex-rail-step.linger .ex-body-face {
     animation: wt-linger-in 260ms ease-out;
   }
   @keyframes wt-linger-in { from { background: var(--success-dim); } to { background: transparent; } }
@@ -488,6 +489,55 @@
     border: 0; border-radius: 11px; background: var(--danger);
     color: white; cursor: pointer; z-index: 0;
   }
+
+  /* Swipe-to-reveal delete on whole exercise rows — removes the exercise
+     from the workout and from the program going forward. The body is the
+     swipe container, so the sliding content clips at its own edge and never
+     crosses into the rail-circle column. */
+  .ex-rail-body.swipe-wrap {
+    position: relative; touch-action: pan-y;
+    clip-path: inset(-6px 0 -6px 0);
+  }
+  .ex-rail-body.swipe-wrap > .ex-body-face {
+    position: relative; z-index: 1;
+    background: var(--card);
+    transition: transform 0.22s cubic-bezier(.2,.7,.2,1);
+    will-change: transform;
+  }
+  .ex-rail-body.swipe-wrap.revealed > .ex-body-face { transform: translateX(-72px); }
+  .ex-delete {
+    /* bottom matches the body's padding-bottom so the button spans exactly
+       the face-covered area */
+    position: absolute; top: 0; right: 0; bottom: 18px; width: 72px;
+    display: flex; align-items: center; justify-content: center;
+    border: 0; border-radius: 11px; background: var(--danger);
+    color: white; cursor: pointer; z-index: 0;
+  }
+  .ex-rail-step:last-child .ex-rail-body.swipe-wrap > .ex-delete { bottom: 0; }
+
+  /* Drag-to-reorder upcoming exercises via the dots handle */
+  .drag-handle {
+    flex-shrink: 0; width: 30px; height: 30px; padding: 0;
+    border: 0; background: transparent; color: var(--text-faint);
+    display: inline-flex; align-items: center; justify-content: center;
+    cursor: grab; touch-action: none;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .ex-rail-step.dragging { z-index: 5; }
+  .ex-rail-step.dragging .drag-handle { cursor: grabbing; }
+  .ex-rail-step.dragging .ex-rail-body {
+    background: var(--card);
+    border-radius: 12px;
+    box-shadow: 0 4px 14px rgba(0,0,0,0.12);
+  }
+  /* Don't clip the lifted row's shadow while dragging */
+  .ex-rail-step.dragging .ex-rail-body.swipe-wrap { clip-path: none; }
+  .ex-rail-step.drag-sib { transition: transform 0.18s ease; }
+
+  /* Inline "+ Add Exercise" picker on the Workout tab */
+  .add-ex-form { display: flex; gap: 8px; margin-top: 10px; align-items: center; }
+  .add-ex-form input { flex: 1; min-width: 0; }
+  .add-ex-form .btn { flex-shrink: 0; }
 
   /* "Last time" reference below the active row — tap to copy into the set */
   .last-chip {


### PR DESCRIPTION
…program

Workout tab gains program editing while training:

- "+ Add Exercise" at the bottom of the exercise list opens an inline picker with the same exercise-library dropdown as Edit Program (pick an existing exercise or type to create one). The new exercise becomes active with 1 set x 0 reps; on finish, the program template records the sets/reps actually performed instead of the placeholder.
- Swipe an exercise row left to reveal a delete button. Deleting removes the exercise from the program going forward; sets already logged this session stay saved and the exercise files into Completed with a "Removed" badge. The last remaining exercise cannot be deleted.
- Drag the dots handle on an upcoming row to reorder the queue; the new order persists to the session, the program template, and the saved program in the library.

Swipe-to-reveal handling is generalized so set rows and exercise rows share one mechanism (innermost swipe-wrap wins). The Today view lines the template up against non-removed session entries. Service worker cache bumped to v30.