### PR TITLE
Program tab redesign: calendar-anchored week tracker (v22)

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 <body>
 <div id="app"></div>
 <nav id="tabs" hidden>
-  <button class="tab" data-tab="today"><span class="ico">⌂</span><span>Today</span></button>
+  <button class="tab" data-tab="today"><span class="ico">▤</span><span>Program</span></button>
   <button class="tab" data-tab="workout"><span class="ico">💪</span><span>Workout</span></button>
   <button class="tab" data-tab="program"><span class="ico">⚙</span><span>Settings</span></button>
   <button class="tab" data-tab="history"><span class="ico">◷</span><span>History</span></button>

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* ---------- State ---------- */
-const APP_VERSION = 'v21 · sw cache fix';
+const APP_VERSION = 'v22 · program calendar';
 
 const EXERCISE_LIBRARY = [
   // Squat / quad

--- a/js/events.js
+++ b/js/events.js
@@ -280,16 +280,44 @@ function onClick(e) {
     return;
   }
 
-  // Today
+  // Program tab (calendar)
   const weekEl = e.target.closest && e.target.closest('[data-select-week]');
   if (weekEl) {
-    selectedWeekIndex = clampWeekIndex(weekEl.dataset.selectWeek);
-    expandedDayKey = defaultExpandedDayKey(selectedWeekIndex);
+    calendarExpanded = true;
     render();
+    return;
+  }
+  const dayCell = e.target.closest && e.target.closest('[data-select-date]');
+  if (dayCell) {
+    selectedDateTs = parseInt(dayCell.dataset.selectDate, 10);
+    expandedPickIdx = null;
+    render();
+    return;
+  }
+  if (e.target.closest && e.target.closest('#toggle-calendar')) {
+    calendarExpanded = !calendarExpanded;
+    render();
+    return;
+  }
+  const editSessionBtn = e.target.closest && e.target.closest('[data-edit-session]');
+  if (editSessionBtn) {
+    editLoggedSession(parseInt(editSessionBtn.dataset.editSession, 10));
+    return;
+  }
+  const delSessionBtn = e.target.closest && e.target.closest('[data-delete-session]');
+  if (delSessionBtn) {
+    deleteLoggedSession(parseInt(delSessionBtn.dataset.deleteSession, 10));
     return;
   }
   if (e.target.dataset.startDay != null) {
     startWorkout(parseInt(e.target.dataset.startDay, 10));
+    return;
+  }
+  const pickEl = e.target.closest && e.target.closest('[data-toggle-pick]');
+  if (pickEl) {
+    const i = parseInt(pickEl.dataset.togglePick, 10);
+    expandedPickIdx = expandedPickIdx === i ? null : i;
+    render();
     return;
   }
   const expandEl = e.target.closest && e.target.closest('[data-expand-day-key]');
@@ -528,13 +556,8 @@ function onClick(e) {
   }
 
   if (e.target.id === 'celebrate-continue') {
-    const c = state.celebration;
-    if (c && c.type === 'workout' && c.fullyComplete) {
-      selectedWeekIndex = c.weekComplete || c.programComplete ? currentWeekIndex() : clampWeekIndex(c.weekIndex);
-      expandedDayKey = c.weekComplete || c.programComplete
-        ? defaultExpandedDayKey(selectedWeekIndex)
-        : dayKey(selectedWeekIndex, c.dayIndex);
-    }
+    selectedDateTs = dayStartTs(Date.now());
+    expandedPickIdx = null;
     state.celebration = null;
     // The session is over — return to Today rather than the empty Workout tab.
     state.tab = 'today';

--- a/js/state.js
+++ b/js/state.js
@@ -30,7 +30,8 @@ function migrate(s) {
   const newCR = {
     startedAt: cr.startedAt || Date.now(),
     weekIndex: typeof cr.weekIndex === 'number' ? cr.weekIndex : 0,
-    completedDayIndices: Array.isArray(cr.completedDayIndices) ? cr.completedDayIndices : []
+    completedDayIndices: Array.isArray(cr.completedDayIndices) ? cr.completedDayIndices : [],
+    calendarAnchored: !!cr.calendarAnchored
   };
   // Migrate old completedDayCount → weekIndex/completedDayIndices
   if (typeof cr.completedDayCount === 'number' && !Array.isArray(cr.completedDayIndices)) {
@@ -41,6 +42,15 @@ function migrate(s) {
     newCR.completedDayIndices = Array.from({ length: remainder }, (_, i) => i);
   }
   s.currentRun = newCR;
+  // Calendar-week model: weeks are real Mon–Sun weeks anchored to startedAt.
+  // Re-anchor once so an existing run's week number maps onto the calendar:
+  // “you're in week N” stays true, with week N being THIS calendar week.
+  if (!newCR.calendarAnchored) {
+    const monday = new Date(); monday.setHours(0, 0, 0, 0);
+    const mondayTs = monday.getTime() - ((monday.getDay() + 6) % 7) * 86400000;
+    newCR.startedAt = mondayTs - (newCR.weekIndex || 0) * 7 * 86400000;
+    newCR.calendarAnchored = true;
+  }
   s.programLibrary = normalizeProgramLibrary(s);
   if (!s.activeProgramId && s.programLibrary.length) {
     s.activeProgramId = s.programLibrary.find(p => !p.archived)?.id || null;
@@ -168,6 +178,9 @@ let expandedExIdx = null;  // index of a completed exercise expanded for editing
 let lingeringExIdx = null; // a just-completed exercise still shown in place, awaiting the next action
 let completedCollapsed = true; // the Completed section starts collapsed
 let addingExercise = false; // the inline "+ Add Exercise" form on the Workout tab is open
+let selectedDateTs = null;    // UI-only selected calendar day on the Program tab (defaults to today)
+let calendarExpanded = false; // Program calendar showing all weeks vs. just the current one
+let expandedPickIdx = null;   // due-workout card expanded to preview its exercises
 let selectedWeekIndex = null; // UI-only selected week on Today
 let expandedDayKey = null;    // UI-only expanded Today day, formatted as "week:day"
 let exerciseLibrarySearch = '';

--- a/js/utils.js
+++ b/js/utils.js
@@ -241,3 +241,75 @@ function sessionSummaryText(session) {
   );
 }
 
+/* ---------- Calendar weeks (Mon–Sun) ----------
+   The program is anchored to real calendar weeks: week 1 is the Mon–Sun
+   window containing currentRun.startedAt, and the "current week" advances
+   with the date — not with workout completion. Required workouts can be done
+   in any order within the week; completion is derived from logged sessions'
+   dates rather than tracked separately. */
+const WEEK_MS = 7 * 86400000;
+
+function dayStartTs(ts) {
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function mondayOfTs(ts) {
+  const d = new Date(dayStartTs(ts));
+  return d.getTime() - ((d.getDay() + 6) % 7) * 86400000;
+}
+
+function programStartMonday() {
+  return mondayOfTs(state.currentRun.startedAt || Date.now());
+}
+
+// Which program week (0-based) a timestamp falls in. May be < 0 or >= weeks.
+function calendarWeekOfTs(ts) {
+  return Math.floor((mondayOfTs(ts) - programStartMonday()) / WEEK_MS);
+}
+
+function weekStartTs(weekIndex) {
+  return programStartMonday() + weekIndex * WEEK_MS;
+}
+
+function sameLocalDay(a, b) {
+  return dayStartTs(a) === dayStartTs(b);
+}
+
+// Whether a saved session resolved every exercise. Newer sessions carry the
+// flag; older ones fall back to a best-effort check against targets.
+function sessionIsComplete(s) {
+  if (!s) return false;
+  if (s.fullyComplete != null) return !!s.fullyComplete;
+  return s.exercises.every(e => e.skipped || e.sets.length >= (e.targetSets || 0));
+}
+
+function sessionsOnDate(ts) {
+  return activeProgramSessions().filter(s => sameLocalDay(s.date, ts));
+}
+
+// Template-day indices completed (fully) in a calendar week, from sessions.
+function completedDayIdxsInCalendarWeek(weekIndex) {
+  if (!state.program) return [];
+  const start = weekStartTs(weekIndex);
+  const end = start + WEEK_MS;
+  const idxs = new Set();
+  activeProgramSessions().forEach(s => {
+    if (s.date >= start && s.date < end && s.dayIndex != null && sessionIsComplete(s)) {
+      idxs.add(s.dayIndex);
+    }
+  });
+  return Array.from(idxs).filter(i => i < state.program.template.length);
+}
+
+// Keep currentRun in line with the calendar. weekIndex may equal program.weeks
+// (or more) once the final week has passed — that's what completes the program.
+function syncCalendarRun() {
+  if (!state.program) return;
+  if (!state.currentRun.startedAt) state.currentRun.startedAt = Date.now();
+  const wk = Math.max(0, calendarWeekOfTs(Date.now()));
+  state.currentRun.weekIndex = wk;
+  state.currentRun.completedDayIndices =
+    completedDayIdxsInCalendarWeek(Math.min(wk, state.program.weeks - 1));
+}

--- a/js/views/today.js
+++ b/js/views/today.js
@@ -1,62 +1,49 @@
+/* ---------- Program tab ----------
+   Calendar-anchored program tracker. Weeks are real Mon–Sun weeks; the
+   required workouts can be completed in any order within the week. Each
+   completed session is logged against its calendar day; tapping a day shows
+   what was logged (editable) or, for today, what is still due. */
+
 Views.today = function() {
-  const lvl = levelFromXp(state.stats.xp);
   const program = state.program;
-  const totalWeeks = program.weeks;
-  const selectedWeek = ensureTodaySelection();
+  syncCalendarRun();
+  if (selectedDateTs == null) selectedDateTs = dayStartTs(Date.now());
+  const currentWeek = currentWeekIndex();
 
   return `
     <div class="today-header">
-      <h1>Today</h1>
-      <button class="btn ghost small" id="edit-program">Edit program</button>
+      <div>
+        <h1>Program</h1>
+        <div class="program-sub">${esc(program.name)}</div>
+      </div>
     </div>
 
     ${programIsComplete() ? programCompleteBannerHtml(program) : ''}
-    ${programStatusHtml(program, selectedWeek, totalWeeks, lvl)}
-
-    ${selectedWeekDayStepperHtml(selectedWeek)}
+    ${weekStepperHtml(currentWeek)}
+    ${calendarCardHtml(currentWeek)}
+    ${selectedDayDetailHtml(currentWeek)}
   `;
 };
 
-function programStatusHtml(program, selectedWeek, totalWeeks, lvl) {
-  const dayCount = program.template.length;
-  return `
-    <div class="card program-status">
-      <div class="program-status-top">
-        <div>
-          <div class="program-name">${esc(program.name)}</div>
-          <div class="program-meta">${totalWeeks} weeks &middot; ${dayCount} workouts per week</div>
-        </div>
-        <div class="metric-chips">
-          <span class="metric-chip">🔥 ${state.stats.streak}</span>
-          <span class="metric-chip">Lv ${lvl}</span>
-          <span class="metric-chip">${state.stats.xp} XP</span>
-        </div>
-      </div>
-      ${weekStepperHtml(selectedWeek)}
-    </div>
-  `;
-}
-
-function weekStepperHtml(selectedWeek) {
-  const currentWeek = state.currentRun.weekIndex || 0;
+/* Week stepper — one circle per program week; a week is checked once all of
+   its required workouts were completed inside that calendar week. */
+function weekStepperHtml(currentWeek) {
   const totalWeeks = state.program.weeks;
+  const requiredPerWeek = state.program.template.length;
   const complete = programIsComplete();
   return `
     <div class="week-stepper" aria-label="Program weeks">
       ${Array.from({length: totalWeeks}, (_, i) => {
-        const done = complete || i < currentWeek;
+        const done = completedDayIdxsInCalendarWeek(i).length >= requiredPerWeek;
         const active = !complete && i === currentWeek;
-        const selected = i === selectedWeek;
         const classes = [
           done ? 'completed' : '',
           active ? 'active' : '',
-          selected ? 'selected' : '',
           (!done && !active) ? 'upcoming' : ''
         ].filter(Boolean).join(' ');
-        const status = done ? 'completed' : active ? 'active' : 'planned';
         return `
-          <button class="week-step ${classes}" data-select-week="${i}" aria-label="Week ${i + 1}, ${status}">
-            <span class="week-step-circle">${done ? '&#10003;' : ''}</span>
+          <button class="week-step ${classes}" data-select-week="${i}" aria-label="Week ${i + 1}${done ? ', completed' : active ? ', current' : ''}">
+            <span class="week-step-circle">${done ? '&#10003;' : i + 1}</span>
             <span class="week-step-label">Week ${i + 1}</span>
           </button>
         `;
@@ -65,92 +52,179 @@ function weekStepperHtml(selectedWeek) {
   `;
 }
 
-function legacyDayCardHtml(day, i, isJustCompleted = false) {
-  const done = dayIsDoneThisWeek(i);
-  const isNext = !done && nextDayIndex() === i;
-  const isExpanded = false;
-  const session = done ? sessionForDayThisWeek(i) : null;
-  const exCount = day.exercises.length;
-  const setCount = day.exercises.reduce((n, e) => n + e.sets, 0);
-
-  const exList = `
-    <div class="exercise-preview-list">
-      ${day.exercises.map(e => `
-        <div class="exercise-preview-row">
-          <span class="target">${e.sets}×${e.reps}</span>
-          <span>${esc(e.name)}</span>
-        </div>
+/* Calendar card — collapsed shows the current week's row; expanded shows the
+   whole program in the same format. */
+function calendarCardHtml(currentWeek) {
+  const program = state.program;
+  const dows = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+  const legend = `
+    <div class="cal-legend">
+      ${program.template.map((d, i) => `
+        <span class="key"><span class="swatch day-c${i % 6}"></span>${esc(d.name || 'Workout ' + (i + 1))}</span>
       `).join('')}
-    </div>
-  `;
+    </div>`;
 
-  if (done) {
-    const skipped = session ? skippedCount(session.exercises) : 0;
-    const summary = sessionSummaryText(session);
-    return `
-      <div class="day-row compact done ${isExpanded ? 'expanded' : ''} ${isJustCompleted ? 'just-completed' : ''}" data-expand-day="${i}">
-        <div class="day-row-head">
-          <div class="day-check small">✓</div>
-          <div class="day-row-main">
-            ${isJustCompleted ? `<div class="subtle">Just completed</div>` : ''}
-            <div class="name">${esc(day.name)}</div>
-            <div class="meta">${session ? 'Done ' + fmtDate(session.date) + ' · ' + summary : 'Done'}</div>
-          </div>
-          ${skipped ? `<span class="badge warn">${skipped} skipped</span>` : `<span class="badge success">Done</span>`}
-          <span class="chevron" aria-hidden="true">${isExpanded ? '▾' : '▸'}</span>
-        </div>
-        ${isExpanded ? completedSessionDetailHtml(session) : ''}
-      </div>
-    `;
-  }
+  const dowRow = `
+    <div class="cal-row">
+      <span></span>
+      ${dows.map(d => `<div class="cal-dow">${d}</div>`).join('')}
+    </div>`;
 
-  if (isNext) {
-    return `
-      <div class="card card-next">
-        <div class="row between" style="margin-bottom:6px;">
-          <div>
-            <div class="subtle">Next up</div>
-            <h3>${esc(day.name)}</h3>
-          </div>
-          <span class="badge">${exCount} ex · ${setCount} sets</span>
-        </div>
-        ${exList}
-        <button class="btn" data-start-day="${i}">Start ${esc(day.name)}</button>
-      </div>
-    `;
-  }
+  const weeks = calendarExpanded
+    ? Array.from({length: program.weeks}, (_, w) => w)
+    : [Math.min(currentWeek, program.weeks - 1)];
 
-  // Other undone: compact, tap to expand exercises
   return `
-    <div class="day-row compact ${isExpanded ? 'expanded' : ''}" data-expand-day="${i}">
-      <div class="day-row-head">
-        <div class="day-row-main">
-          <div class="name">${esc(day.name)}</div>
-          <div class="meta">${exCount} ex · ${setCount} sets</div>
-        </div>
-        <span class="chevron" aria-hidden="true">${isExpanded ? '▾' : '▸'}</span>
-        <button class="btn secondary small" data-start-day="${i}">Start</button>
+    <div class="card cal-card">
+      <div class="row between" style="align-items:flex-start;">
+        <div class="program-name">Calendar</div>
+        ${legend}
       </div>
-      ${isExpanded ? `<div class="day-row-detail">${exList}</div>` : ''}
+      <div class="cal-rows">
+        ${dowRow}
+        ${weeks.map(w => calendarWeekRowHtml(w, currentWeek)).join('')}
+      </div>
+      <button class="expand-btn" id="toggle-calendar" type="button">
+        ${calendarExpanded ? 'This week only <span class="chev">&#9650;</span>' : 'Full program <span class="chev">&#9660;</span>'}
+      </button>
     </div>
   `;
 }
 
-function completedSessionDetailHtml(session) {
-  if (!session) {
-    return `<div class="day-row-detail"><div class="faint">No session details saved for this workout.</div></div>`;
-  }
+function calendarWeekRowHtml(w, currentWeek) {
+  const base = new Date(weekStartTs(w));
+  const isActiveRow = w === currentWeek && !programIsComplete();
+  const cells = Array.from({length: 7}, (_, i) => {
+    const d = new Date(base.getFullYear(), base.getMonth(), base.getDate() + i);
+    return calendarCellHtml(d.getTime());
+  }).join('');
   return `
-    <div class="day-row-detail">
-      ${session.exercises.map(e => `
-        <div class="session-ex-row ${e.skipped ? 'skipped' : ''}">
-          <div class="row between">
-            <span class="nm">${esc(e.name)}</span>
-            <span class="sts">${sessionExerciseStatus(e)}</span>
+    <div class="cal-row ${isActiveRow ? 'active' : ''}">
+      <div class="cal-wk-label">W${w + 1}</div>
+      ${cells}
+    </div>`;
+}
+
+function calendarCellHtml(ts) {
+  const todayTs = dayStartTs(Date.now());
+  const future = ts > todayTs;
+  const sessions = sessionsOnDate(ts);
+  const last = sessions.length ? sessions[sessions.length - 1] : null;
+  const colorCls = last ? ' logged day-c' + ((last.dayIndex || 0) % 6) : '';
+  const cls = [
+    'cal-cell',
+    colorCls,
+    ts === todayTs ? 'today' : '',
+    (ts === selectedDateTs && ts !== todayTs) ? 'selected' : '',
+    future ? 'future' : ''
+  ].filter(Boolean).join(' ');
+  const tap = future ? '' : ` data-select-date="${ts}"`;
+  return `<div class="${cls}"${tap}><span class="cd">${new Date(ts).getDate()}</span></div>`;
+}
+
+/* Detail under the calendar — always reflects the selected day. */
+function selectedDayDetailHtml(currentWeek) {
+  const ts = selectedDateTs;
+  const isToday = sameLocalDay(ts, Date.now());
+  const sessions = sessionsOnDate(ts);
+  const dateLabel = new Date(ts).toLocaleDateString(undefined, { weekday: 'long', month: 'short', day: 'numeric' });
+  const label = isToday ? 'Today &middot; ' + esc(dateLabel) : esc(dateLabel);
+
+  let html = `<div class="section-label cal-day-label">${label}</div>`;
+
+  sessions.forEach(s => {
+    html += loggedSessionCardHtml(s, state.sessions.indexOf(s));
+  });
+
+  if (isToday && !programIsComplete()) {
+    if (state.active) {
+      html += `
+        <div class="card pick-card">
+          <div class="pick-head">
+            <span class="pick-dot day-c${(state.active.dayIndex || 0) % 6}"></span>
+            <div class="pick-main">
+              <div class="pick-name">${esc(state.active.dayName)}</div>
+              <div class="pick-meta">Workout in progress</div>
+            </div>
+            <button class="btn small" data-tab="workout">Continue</button>
           </div>
-          <div class="session-set-summary">${sessionExerciseSetSummary(e)}</div>
+        </div>`;
+    } else {
+      const due = state.program.template
+        .map((d, i) => ({ d, i }))
+        .filter(({ i }) => !state.currentRun.completedDayIndices.includes(i));
+      if (due.length) {
+        due.forEach(({ d, i }) => { html += pickCardHtml(d, i); });
+        html += `<div class="faint cal-hint">Any order &mdash; finishing a workout logs it to today. Tap a card to see its exercises.</div>`;
+      } else if (!sessions.length) {
+        html += weekCompleteCardHtml();
+      } else {
+        html += weekCompleteCardHtml();
+      }
+    }
+  } else if (!sessions.length && !isToday) {
+    html += `<div class="card compact"><div class="subtle">Nothing logged on this day.</div></div>`;
+  } else if (!sessions.length && isToday && programIsComplete()) {
+    html += `<div class="card compact"><div class="subtle">Program finished &mdash; start it again or pick a new one in Settings.</div></div>`;
+  }
+
+  return html;
+}
+
+function weekCompleteCardHtml() {
+  return `
+    <div class="card">
+      <div class="program-name">Week complete &#10003;</div>
+      <div class="program-meta">All ${state.program.template.length} workouts logged this week. Next week unlocks Monday.</div>
+    </div>`;
+}
+
+/* A workout still due this week — tap to preview exercises, Start to begin. */
+function pickCardHtml(day, i) {
+  const expanded = expandedPickIdx === i;
+  const exCount = day.exercises.length;
+  const setTotal = day.exercises.reduce((n, e) => n + e.sets, 0);
+  return `
+    <div class="card pick-card" data-toggle-pick="${i}">
+      <div class="pick-head">
+        <span class="pick-dot day-c${i % 6}"></span>
+        <div class="pick-main">
+          <div class="pick-name">${esc(day.name || 'Workout ' + (i + 1))}</div>
+          <div class="pick-meta">${exCount} exercise${exCount === 1 ? '' : 's'} &middot; ${setTotal} sets</div>
         </div>
-      `).join('')}
+        <button class="btn small" data-start-day="${i}">Start</button>
+        <span class="pick-chev">${expanded ? '&#9662;' : '&#9656;'}</span>
+      </div>
+      ${expanded ? `
+        <div class="pick-ex">
+          ${day.exercises.map(e => `
+            <div class="pick-ex-row"><span class="nm">${esc(e.name)}</span><span class="tgt">${e.sets} &times; ${e.reps}</span></div>
+          `).join('')}
+        </div>` : ''}
+    </div>
+  `;
+}
+
+/* A logged session on the selected day — editable / deletable. */
+function loggedSessionCardHtml(session, sessionIdx) {
+  const dayIdx = (session.dayIndex || 0) % 6;
+  const partial = !sessionIsComplete(session);
+  const busy = !!state.active;
+  return `
+    <div class="card logged-day-card">
+      <div class="logged-session">
+        <span class="pick-dot day-c${dayIdx}"></span>
+        <div class="log-main">
+          <div class="log-name">${esc(session.dayName || 'Workout ' + ((session.dayIndex || 0) + 1))}</div>
+          <div class="log-meta">${sessionSummaryText(session)}</div>
+        </div>
+        ${partial ? '<span class="badge warn">Partial</span>' : '<span class="badge success">Logged</span>'}
+      </div>
+      ${busy ? '' : `
+      <div class="dd-actions">
+        <button class="btn secondary small" data-edit-session="${sessionIdx}">Edit log</button>
+        <button class="btn ghost-danger small" data-delete-session="${sessionIdx}">Delete</button>
+      </div>`}
     </div>
   `;
 }
@@ -166,167 +240,3 @@ function programCompleteBannerHtml(program) {
     </div>
   `;
 }
-
-function selectedWeekDayStepperHtml(weekIndex) {
-  const days = state.program.template;
-  const complete = completedDayCountForWeek(weekIndex);
-  const status = programIsComplete() || weekIndex < (state.currentRun.weekIndex || 0)
-    ? 'Complete'
-    : weekIndex === (state.currentRun.weekIndex || 0)
-      ? 'In progress'
-      : 'Planned';
-  return `
-    <div class="card day-stepper-card">
-      <div class="week-detail-head">
-        <div>
-          <div class="section-label">Week ${weekIndex + 1}</div>
-          <h2>${status}</h2>
-        </div>
-        <span class="badge ${status === 'Complete' ? 'success' : ''}">${complete}/${days.length} workouts</span>
-      </div>
-      <div class="day-stepper">
-        ${days.map((day, i) => dayStepHtml(day, weekIndex, i)).join('')}
-      </div>
-    </div>
-  `;
-}
-
-function dayStepHtml(day, weekIndex, dayIndex) {
-  const key = dayKey(weekIndex, dayIndex);
-  const done = dayIsDoneInWeek(weekIndex, dayIndex);
-  const active = !done && activeDayIndexForWeek(weekIndex) === dayIndex;
-  const expanded = expandedDayKey === key;
-  const session = sessionForDay(weekIndex, dayIndex);
-  const skipped = session ? skippedCount(session.exercises) : 0;
-  const exCount = day.exercises.length;
-  const setCount = day.exercises.reduce((n, e) => n + e.sets, 0);
-  const canStart = active && !state.active;
-  const statusText = done
-    ? (session ? `Done ${fmtDate(session.date)} &middot; ${sessionSummaryText(session)}` : 'Done')
-    : active
-      ? 'Active workout'
-      : `${exCount} exercises &middot; ${setCount} sets`;
-  const badge = done
-    ? (skipped ? `<span class="badge warn">${skipped} skipped</span>` : `<span class="badge success">Done</span>`)
-    : active
-      ? `<span class="badge success">Active</span>`
-      : `<span class="badge">Planned</span>`;
-
-  return `
-    <div class="day-step ${done ? 'completed' : ''} ${active ? 'active' : ''} ${expanded ? 'expanded' : ''}">
-      <div class="day-step-rail">
-        <button class="day-step-circle" data-expand-day-key="${key}" aria-label="Toggle Workout ${dayIndex + 1}">
-          ${done ? '&#10003;' : dayIndex + 1}
-        </button>
-      </div>
-      <div class="day-step-body">
-        <button class="day-step-summary" data-expand-day-key="${key}">
-          <div class="day-step-copy">
-            <div class="day-step-eyebrow">Workout ${dayIndex + 1}</div>
-            <div class="day-step-name">${esc(day.name)}</div>
-            <div class="day-step-meta">${statusText}</div>
-          </div>
-          ${badge}
-          <span class="chevron" aria-hidden="true">${expanded ? '&#9662;' : '&#9656;'}</span>
-        </button>
-        ${expanded ? dayStepDetailHtml(day, weekIndex, dayIndex, session, canStart) : ''}
-      </div>
-    </div>
-  `;
-}
-
-function dayStepDetailHtml(day, weekIndex, dayIndex, session, canStart) {
-  return `
-    <div class="day-step-detail">
-      ${exerciseStepperHtml(day, weekIndex, dayIndex, session)}
-      ${canStart ? `<button class="btn" data-start-day="${dayIndex}">Start ${esc(day.name)}</button>` : ''}
-    </div>
-  `;
-}
-
-function matchingSessionExercise(session, planned, index, used) {
-  if (!session || !Array.isArray(session.exercises)) return null;
-  const sameIndex = session.exercises[index];
-  if (sameIndex && !used.has(index) && sameIndex.name === planned.name) {
-    used.add(index);
-    return sameIndex;
-  }
-  const matchIndex = session.exercises.findIndex((e, i) => !used.has(i) && e.name === planned.name);
-  if (matchIndex >= 0) {
-    used.add(matchIndex);
-    return session.exercises[matchIndex];
-  }
-  return null;
-}
-
-function exerciseStepperHtml(day, weekIndex, dayIndex, session) {
-  const activeWorkout = state.active &&
-    state.active.weekIndex === weekIndex &&
-    state.active.dayIndex === dayIndex
-      ? state.active
-      : null;
-  // Exercises removed mid-workout stay in the active session (to keep their
-  // logged sets) but no longer exist in the template, so line the template up
-  // against the non-removed entries only.
-  const liveExercises = activeWorkout
-    ? activeWorkout.exercises.filter(e => !e.removed)
-    : null;
-  const firstOpen = liveExercises
-    ? liveExercises.findIndex(e => !exerciseIsResolved(e))
-    : -1;
-  const usedSessionExercises = new Set();
-
-  return `
-    <div class="exercise-stepper">
-      ${day.exercises.map((planned, i) => {
-        const activeEx = liveExercises ? liveExercises[i] : null;
-        const sessionEx = activeEx ? null : matchingSessionExercise(session, planned, i, usedSessionExercises);
-        const source = activeEx || sessionEx || planned;
-        const targetSets = source.targetSets || planned.sets;
-        const targetReps = source.targetReps || planned.reps;
-        let status = 'blank';
-        if (activeEx) {
-          if (activeEx.skipped) status = 'skipped';
-          else if (exerciseIsComplete(activeEx)) status = 'completed';
-          else if (i === firstOpen) status = 'active';
-        } else if (sessionEx) {
-          const sessionSets = Array.isArray(sessionEx.sets) ? sessionEx.sets.length : 0;
-          const sessionTarget = sessionEx.targetSets || planned.sets;
-          status = sessionEx.skipped ? 'skipped' : sessionSets >= sessionTarget ? 'completed' : 'blank';
-        }
-        const loggedSummary = sessionEx
-          ? sessionExerciseSetSummary(sessionEx) || sessionExerciseStatus(sessionEx)
-          : activeEx && activeEx.sets.length
-            ? `${activeEx.sets.length} of ${targetSets} sets logged`
-            : '';
-        return `
-          <div class="exercise-step ${status}">
-            <span class="exercise-step-dot">${status === 'completed' || status === 'skipped' ? '&#10003;' : ''}</span>
-            <div class="exercise-step-main">
-              <div class="exercise-step-name">${esc(planned.name)}</div>
-              <div class="exercise-step-meta">${targetSets}&times;${targetReps}${loggedSummary ? ` &middot; ${esc(loggedSummary)}` : ''}</div>
-            </div>
-          </div>
-        `;
-      }).join('')}
-    </div>
-  `;
-}
-
-function programCompleteView() {
-  return `
-    <div class="celebrate">
-      <div class="big">🏆</div>
-      <h1>Program Complete!</h1>
-      <p class="sub">You finished all ${state.program.weeks} weeks of ${esc(state.program.name)}.</p>
-      <div class="stats" style="max-width:320px; margin:24px auto;">
-        <div class="stat"><div class="v">${state.stats.xp}</div><div class="k">Total XP</div></div>
-        <div class="stat"><div class="v">Lv ${levelFromXp(state.stats.xp)}</div><div class="k">Level</div></div>
-        <div class="stat"><div class="v">${state.sessions.length}</div><div class="k">Workouts</div></div>
-      </div>
-      <button class="btn" id="restart-program">Start Program Again</button>
-      <button class="btn ghost" id="edit-program" style="margin-top:8px;">Edit Program</button>
-    </div>
-  `;
-}
-

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -2,7 +2,7 @@
 function startWorkout(dayIndex) {
   if (programIsComplete()) return;
   if (dayIsDoneThisWeek(dayIndex)) return;
-  if (dayIndex !== nextDayIndex()) return;
+  if (state.active) return;
   const day = state.program.template[dayIndex];
   if (!day) return;
   editingSet = null;
@@ -607,6 +607,12 @@ function logCurrentSet(row) {
 function finishWorkout(opts = {}) {
   const a = state.active;
   if (!a) return;
+  // Editing a previously-logged session: replace it in place. No XP, streak
+  // or celebration — the original workout already earned those.
+  if (a.editOfDate != null) {
+    finishSessionEdit(a);
+    return;
+  }
   persistAddedExerciseTargets(a);
   const exsWithSets = a.exercises.filter(e => e.sets.length > 0);
   const sessionExercises = a.exercises.filter(e => e.sets.length > 0 || e.skipped);
@@ -643,6 +649,7 @@ function finishWorkout(opts = {}) {
   // Determine if the day has been resolved: every exercise logged or explicitly skipped.
   const fullyComplete = !opts.partial &&
     a.exercises.every(exerciseIsResolved);
+  session.fullyComplete = fullyComplete;
 
   let xpEarned = 0;
   let weekComplete = false;
@@ -684,15 +691,14 @@ function finishWorkout(opts = {}) {
       state.currentRun.completedDayIndices.push(a.dayIndex);
     }
 
-    // Week complete?
+    // Week complete? Weeks are calendar weeks now — the week number advances
+    // with the date (syncCalendarRun), never here.
     if (state.currentRun.completedDayIndices.length >= state.program.template.length) {
       weekComplete = true;
       xpEarned += 500;
-      state.currentRun.weekIndex += 1;
-      state.currentRun.completedDayIndices = [];
 
-      // Program complete?
-      if (programIsComplete()) {
+      // Final week fully done = program complete.
+      if (currentWeekIndex() >= state.program.weeks - 1) {
         programComplete = true;
         xpEarned += 2500;
       }
@@ -739,3 +745,95 @@ function finishWorkout(opts = {}) {
   render();
 }
 
+/* ---------- Logged-session edit / delete (Program calendar) ---------- */
+// Reopen a saved session in the Workout tab. Finishing replaces the original
+// log (same date) instead of appending a new one.
+function editLoggedSession(sessionIdx) {
+  const s = state.sessions[sessionIdx];
+  if (!s || state.active) return;
+  editingSet = null;
+  expandedExIdx = null;
+  lingeringExIdx = null;
+  completedCollapsed = true;
+  addingExercise = false;
+  state.active = {
+    programId: s.programId || state.activeProgramId || null,
+    programName: s.programName || (state.program && state.program.name) || '',
+    weekIndex: s.weekIndex || 0,
+    dayIndex: s.dayIndex || 0,
+    dayName: s.dayName || 'Workout ' + ((s.dayIndex || 0) + 1),
+    startedAt: s.date,
+    editOfDate: s.date,
+    activeExIdx: -1,
+    exercises: s.exercises.map(e => {
+      const targetSets = e.targetSets || e.sets.length || 1;
+      return {
+        name: e.name,
+        targetSets,
+        targetReps: e.targetReps || 0,
+        sets: structuredClone(e.sets),
+        skipped: !!e.skipped,
+        removed: !!e.removed,
+        extraSets: Math.max(0, e.sets.length - targetSets)
+      };
+    })
+  };
+  state.tab = 'workout';
+  save();
+  render();
+}
+
+// Swap the edited exercises back into the original session record.
+function finishSessionEdit(a) {
+  const idx = state.sessions.findIndex(s => s.date === a.editOfDate);
+  const editedExercises = a.exercises.filter(e => e.sets.length > 0 || e.skipped);
+  if (idx >= 0) {
+    if (editedExercises.length) {
+      const orig = state.sessions[idx];
+      state.sessions[idx] = Object.assign({}, orig, {
+        exercises: editedExercises.map(e => ({
+          name: e.name,
+          sets: e.sets,
+          skipped: !!e.skipped,
+          skippedAt: e.skippedAt || null,
+          removed: !!e.removed,
+          targetSets: e.targetSets,
+          targetReps: e.targetReps
+        })),
+        fullyComplete: a.exercises.every(exerciseIsResolved)
+      });
+    } else {
+      // Every set was deleted — the log is gone.
+      state.sessions.splice(idx, 1);
+    }
+  }
+  syncCalendarRun();
+  state.active = null;
+  editingSet = null;
+  expandedExIdx = null;
+  lingeringExIdx = null;
+  completedCollapsed = true;
+  addingExercise = false;
+  state.tab = 'today';
+  save();
+  render();
+}
+
+function deleteLoggedSession(sessionIdx) {
+  const s = state.sessions[sessionIdx];
+  if (!s) return;
+  const when = new Date(s.date).toLocaleDateString(undefined, { weekday: 'long', month: 'short', day: 'numeric' });
+  showModal({
+    title: 'Delete this log?',
+    body: (s.dayName || 'This workout') + ' on ' + when + ' will be removed from the calendar. This cannot be undone.',
+    confirmText: 'Delete',
+    danger: true,
+    onConfirm: () => {
+      state.sessions.splice(sessionIdx, 1);
+      syncCalendarRun();
+      closeModal();
+      save();
+      render();
+    }
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1369,3 +1369,96 @@
     margin: 32px 0 8px;
     font-variant-numeric: tabular-nums;
   }
+
+  /* ---------- Program tab: calendar tracker ---------- */
+  .program-sub { color: var(--text-dim); font-size: 15px; font-weight: 500; margin-top: 3px; }
+
+  /* Per-workout colors (template day index mod 6). c0 = app accent. */
+  :root {
+    --day-c0: #0071e3;
+    --day-c1: oklch(0.55 0.18 305);
+    --day-c2: oklch(0.58 0.12 175);
+    --day-c3: oklch(0.68 0.15 65);
+    --day-c4: oklch(0.62 0.17 0);
+    --day-c5: oklch(0.62 0.17 145);
+  }
+  .day-c0 { --day-c: var(--day-c0); }
+  .day-c1 { --day-c: var(--day-c1); }
+  .day-c2 { --day-c: var(--day-c2); }
+  .day-c3 { --day-c: var(--day-c3); }
+  .day-c4 { --day-c: var(--day-c4); }
+  .day-c5 { --day-c: var(--day-c5); }
+
+  .cal-card .program-name { font-size: 19px; font-weight: 700; }
+  .cal-legend {
+    display: flex; gap: 5px 12px; align-items: center; justify-content: flex-end;
+    flex-wrap: wrap; max-width: 55%; padding-top: 3px;
+  }
+  .cal-legend .key {
+    display: inline-flex; align-items: center; gap: 5px;
+    font-size: 12px; font-weight: 600; color: var(--text-dim); white-space: nowrap;
+  }
+  .cal-legend .swatch { width: 8px; height: 8px; border-radius: 50%; background: var(--day-c); flex-shrink: 0; }
+
+  .cal-rows { display: flex; flex-direction: column; gap: 3px; margin-top: 12px; }
+  .cal-row { display: grid; grid-template-columns: 26px repeat(7, 1fr); gap: 3px; align-items: center; }
+  .cal-row.active { background: var(--accent-dim); border-radius: 999px; margin: 0 -6px; padding: 3px 6px; }
+  .cal-row.active .cal-wk-label { color: var(--accent); }
+  .cal-row.active .cal-cell { background: white; }
+  .cal-wk-label {
+    display: flex; align-items: center; justify-content: center;
+    font-size: 10px; font-weight: 700; color: var(--text-faint);
+    text-transform: uppercase; letter-spacing: 0.03em;
+  }
+  .cal-dow { text-align: center; font-size: 11px; font-weight: 600; color: var(--text-dim); padding-bottom: 2px; }
+  .cal-cell {
+    aspect-ratio: 1; border-radius: 50%; background: var(--bg);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums;
+    color: var(--text-dim); cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .cal-cell.future { color: var(--text-faint); background: color-mix(in srgb, var(--bg) 55%, white); cursor: default; }
+  .cal-cell.logged { background: var(--day-c); color: white; }
+  .cal-row.active .cal-cell.logged { background: var(--day-c); }
+  .cal-cell.today { box-shadow: 0 0 0 2px var(--accent); color: var(--accent); background: var(--accent-dim); }
+  .cal-cell.today.logged { color: white; background: var(--day-c); }
+  .cal-cell.selected { box-shadow: 0 0 0 2px var(--text); }
+
+  .expand-btn {
+    width: calc(100% + 32px); margin: 12px -16px -16px; padding: 11px 0 13px;
+    border: none; border-top: 1px solid var(--border); background: transparent;
+    color: var(--accent); font-family: inherit; font-size: 14px; font-weight: 600;
+    display: flex; align-items: center; justify-content: center; gap: 6px; cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .expand-btn .chev { font-size: 11px; }
+
+  .cal-day-label { margin: 18px 2px 8px; }
+  .cal-hint { margin: 2px 2px 0; }
+
+  /* Due-workout cards (today) */
+  .pick-card { -webkit-tap-highlight-color: transparent; }
+  .pick-head { display: flex; align-items: center; gap: 12px; }
+  .pick-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--day-c); flex-shrink: 0; }
+  .pick-main { flex: 1; min-width: 0; }
+  .pick-name { font-size: 17px; font-weight: 700; }
+  .pick-meta { font-size: 13px; color: var(--text-dim); margin-top: 1px; }
+  .pick-chev { color: var(--text-faint); font-size: 14px; flex-shrink: 0; }
+  .pick-ex { margin-top: 12px; border-top: 1px solid var(--border); padding-top: 6px; }
+  .pick-ex-row {
+    display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: baseline;
+    padding: 5px 0; font-size: 14px; border-bottom: 1px solid var(--border);
+  }
+  .pick-ex-row:last-child { border-bottom: none; }
+  .pick-ex-row .nm { font-weight: 500; }
+  .pick-ex-row .tgt { color: var(--text-faint); font-variant-numeric: tabular-nums; }
+
+  /* Logged-session card on a selected day */
+  .logged-session { display: flex; align-items: center; gap: 12px; }
+  .logged-session .log-main { flex: 1; min-width: 0; }
+  .logged-session .log-name { font-size: 16px; font-weight: 700; }
+  .logged-session .log-meta { font-size: 13px; color: var(--text-dim); margin-top: 1px; font-variant-numeric: tabular-nums; }
+  .dd-actions { display: flex; gap: 8px; margin-top: 12px; }
+  .dd-actions .btn { flex: 1; }
+  .btn.ghost-danger { background: #fdeceb; color: var(--danger); }


### PR DESCRIPTION
## What changed

Implements the Program tab redesign from the Claude Design handoff bundle (refined option A from the design session). The Today tab becomes a **Program** tracker built around a Mon–Sun calendar anchored to the program's start date.

- **Week stepper** across the whole program; weeks advance with the date, not with completion
- **Calendar card** with per-workout color legend (top-right), showing the current week; expandable to the full program grid with the active week highlighted
- **Day selection** — tapping a past/current day shows its logged session(s) below with **Edit log / Delete**
- **Any-order workouts** — the week's due workouts are all startable on the active day (the old "next workout only" rule is gone); cards expand to preview exercises and set × rep targets
- **Edit log** reopens the session in the Workout tab and replaces the original on finish (no duplicate, no double XP); **Delete** removes it and week/calendar state re-derives automatically
- **Migration** — existing users' stored week number is re-anchored once to the current calendar week
- `APP_VERSION` bumped to v22 to bust the service-worker cache

## Why

Designed and iterated in claude.ai/design (see the handoff bundle's chat transcripts): the goal was an overall program tracker so users can see how they're tracking over time, complete the week's workouts in any order, and edit/delete logged days.

## Reviewer notes

- The design bundle's base code was byte-identical to `master` at a100c04, so the changeset applied cleanly with no merge adjustments.
- Verified end-to-end in the running app: fresh install → choose program → calendar renders → expand/collapse → start → log all sets → finish → celebration → session logged against today with Edit/Delete, remaining workouts still startable. No console errors.
- Week completion is now *derived* from logged session dates (`completedDayIdxsInCalendarWeek`), so deleting/editing a log automatically updates week state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)