### PR TITLE
Add a 3-dot menu (Delete / Skip) on the active exercise; fix set-tras…

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -112,6 +112,15 @@ function closeAllReveals(except) {
   });
 }
 
+/* ---------- Exercise overflow (3-dot) menu ---------- */
+function closeExMenus() {
+  document.querySelectorAll('.ex-menu-wrap.open').forEach(w => {
+    w.classList.remove('open');
+    const b = w.querySelector('.ex-menu-btn');
+    if (b) b.setAttribute('aria-expanded', 'false');
+  });
+}
+
 function onTouchStart(e) {
   // A fresh touch is deliberate intent — never suppress its click.
   suppressNextClick = false;
@@ -121,7 +130,7 @@ function onTouchStart(e) {
   const wrap = e.target.closest && e.target.closest('.swipe-wrap');
   // Don't begin a swipe from a trash button or from a text input (so the
   // active row's weight field keeps its native touch behaviour).
-  if (!wrap || (e.target.closest && e.target.closest('.set-delete, .ex-delete, .drag-handle, input'))) { swipe = null; return; }
+  if (!wrap || (e.target.closest && e.target.closest('.set-delete, .drag-handle, input'))) { swipe = null; return; }
   const face = wrap.querySelector(':scope > .swipe-face');
   if (!face) { swipe = null; return; }
   const t = e.touches[0];
@@ -145,6 +154,7 @@ function onTouchMove(e) {
   if (swipe.vertical) { swipe = null; return; } // it's a scroll — let it through
   if (!swipe.horizontal) return;
   e.preventDefault(); // claim the gesture so the page doesn't scroll
+  swipe.wrap.classList.add('swiping'); // reveal the trash only while dragging
   let tx = Math.max(-SWIPE_REVEAL, Math.min(0, swipe.base + dx));
   swipe.curr = tx;
   swipe.face.style.transition = 'none';
@@ -155,6 +165,7 @@ function onTouchEnd() {
   if (!swipe) return;
   const s = swipe;
   swipe = null;
+  s.wrap.classList.remove('swiping');
   if (!s.horizontal) return;
   // Hand the snap back to the CSS class transition.
   s.face.style.transition = '';
@@ -180,6 +191,13 @@ function onClick(e) {
   // The reorder handle is drag-only — a stray tap on it must not select the row.
   if (e.target.closest && e.target.closest('.drag-handle')) return;
 
+  // A tap outside an open exercise menu dismisses it, then proceeds normally.
+  // Taps inside the menu (toggle button or items) are handled further down.
+  if (document.querySelector('.ex-menu-wrap.open') &&
+      !(e.target.closest && e.target.closest('.ex-menu-wrap'))) {
+    closeExMenus();
+  }
+
   // Tap the revealed trash button to delete that set.
   const delBtn = e.target.closest && e.target.closest('[data-act="delete-set"]');
   if (delBtn) {
@@ -187,10 +205,11 @@ function onClick(e) {
     removeSet(exIdx, si);
     return;
   }
-  // Tap the revealed trash button on an exercise to remove it from the
+  // "Delete exercise" in the 3-dot menu — remove the whole exercise from the
   // workout and from the program going forward.
   const exDelBtn = e.target.closest && e.target.closest('[data-act="delete-ex"]');
   if (exDelBtn) {
+    closeExMenus();
     closeAllReveals(null);
     removeExerciseFromWorkout(+exDelBtn.dataset.exIdx);
     return;
@@ -471,8 +490,18 @@ function onClick(e) {
     endWorkoutFlow();
     return;
   }
-  if (e.target.dataset.act === 'skip-ex') {
-    const exIdx = parseInt(e.target.dataset.exIdx, 10);
+  // 3-dot exercise menu — toggle open/closed.
+  const exMenuBtn = e.target.closest && e.target.closest('[data-act="ex-menu"]');
+  if (exMenuBtn) {
+    const wrap = exMenuBtn.closest('.ex-menu-wrap');
+    const open = wrap.classList.toggle('open');
+    exMenuBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    return;
+  }
+  const skipExBtn = e.target.closest && e.target.closest('[data-act="skip-ex"]');
+  if (skipExBtn) {
+    closeExMenus();
+    const exIdx = parseInt(skipExBtn.dataset.exIdx, 10);
     if (withUnloggedSetGuard(() => skipExercise(exIdx), 'Skip without set')) return;
     skipExercise(exIdx);
     return;
@@ -633,6 +662,10 @@ function onInput(e) {
 }
 
 function onKeydown(e) {
+  if (e.key === 'Escape' && document.querySelector('.ex-menu-wrap.open')) {
+    closeExMenus();
+    return;
+  }
   if (e.key === 'Enter') {
     if (e.target.id === 'new-exercise-name') {
       e.preventDefault();

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -80,9 +80,7 @@ function activeStepHtml(ex, i) {
   return `
     <div class="ex-rail-step active" data-ex-idx="${i}">
       <div class="ex-rail-node"><span class="ex-rail-circle"></span></div>
-      <div class="ex-rail-body swipe-wrap">
-        ${exDeleteBtnHtml(i)}
-        <div class="ex-body-face swipe-face">
+      <div class="ex-rail-body">
         <div class="dense-line">
           <div style="min-width:0;">
             <div class="rail-eyebrow active">Active</div>
@@ -90,7 +88,13 @@ function activeStepHtml(ex, i) {
           </div>
           <div class="row" style="gap:6px;">
             <span class="badge">${ex.sets.length}/${exerciseSlots(ex)}</span>
-            <button class="btn ghost small skip-ex-btn" data-act="skip-ex" data-ex-idx="${i}">${skipLabel}</button>
+            <div class="ex-menu-wrap">
+              <button type="button" class="ex-menu-btn" data-act="ex-menu" aria-label="Exercise options" aria-haspopup="true" aria-expanded="false">${DOTS_SVG}</button>
+              <div class="ex-menu" role="menu">
+                <button type="button" class="ex-menu-item danger" data-act="delete-ex" data-ex-idx="${i}" role="menuitem">Delete exercise</button>
+                <button type="button" class="ex-menu-item" data-act="skip-ex" data-ex-idx="${i}" role="menuitem">${skipLabel}</button>
+              </div>
+            </div>
           </div>
         </div>
         <div class="ex-rail-meta" style="margin:2px 0 0;">Target ${ex.targetSets} × ${ex.targetReps}</div>
@@ -98,7 +102,6 @@ function activeStepHtml(ex, i) {
           ${Array.from({length: exerciseSlots(ex)}, (_, si) => setRowHtml(ex, i, si, true)).join('')}
         </div>
         ${addSetBtnHtml(i)}
-        </div>
       </div>
     </div>
   `;
@@ -125,10 +128,6 @@ function addExerciseRowHtml() {
   `;
 }
 
-function exDeleteBtnHtml(exIdx) {
-  return `<button type="button" class="ex-delete" data-act="delete-ex" data-ex-idx="${exIdx}" aria-label="Remove exercise" tabindex="-1">${TRASH_SVG}</button>`;
-}
-
 const DRAG_SVG = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><circle cx="5" cy="3" r="1.5"/><circle cx="11" cy="3" r="1.5"/><circle cx="5" cy="8" r="1.5"/><circle cx="11" cy="8" r="1.5"/><circle cx="5" cy="13" r="1.5"/><circle cx="11" cy="13" r="1.5"/></svg>';
 
 function dragHandleHtml() {
@@ -148,15 +147,12 @@ function upNextStepHtml(ex, i) {
   return `
     <div class="ex-rail-step upcoming dense-collapsed" data-ex-idx="${i}">
       <div class="ex-rail-node"><span class="ex-rail-circle"></span></div>
-      <div class="ex-rail-body selectable swipe-wrap" data-select-active="${i}">
-        ${exDeleteBtnHtml(i)}
-        <div class="ex-body-face swipe-face">
-          <div class="dense-line">
-            <div class="ex-rail-name">${name}</div>
-            <span class="row" style="gap:2px;">${badge}${dragHandleHtml()}</span>
-          </div>
-          <div class="dense-summary">${summary}</div>
+      <div class="ex-rail-body selectable" data-select-active="${i}">
+        <div class="dense-line">
+          <div class="ex-rail-name">${name}</div>
+          <span class="row" style="gap:2px;">${badge}${dragHandleHtml()}</span>
         </div>
+        <div class="dense-summary">${summary}</div>
       </div>
     </div>
   `;
@@ -169,9 +165,7 @@ function lingerStepHtml(ex, i) {
   return `
     <div class="ex-rail-step completed expanded linger" data-ex-idx="${i}">
       <div class="ex-rail-node"><span class="ex-rail-circle">✓</span></div>
-      <div class="ex-rail-body swipe-wrap">
-        ${exDeleteBtnHtml(i)}
-        <div class="ex-body-face swipe-face">
+      <div class="ex-rail-body">
         <div class="dense-line">
           <div style="min-width:0;">
             <div class="rail-eyebrow done">Completed</div>
@@ -184,7 +178,6 @@ function lingerStepHtml(ex, i) {
           ${ex.sets.map((s, si) => setRowHtml(ex, i, si, false)).join('')}
         </div>
         ${addSetBtnHtml(i)}
-        </div>
       </div>
     </div>
   `;
@@ -228,11 +221,10 @@ function completedRowHtml(ex, i) {
       : `<span class="badge success">${ex.sets.length}/${exerciseSlots(ex)} ✓</span>`;
   const editable = ex.sets.length > 0;
   const expanded = editable && i === expandedExIdx;
-  // An already-removed exercise can't be swiped away again.
-  const wrapOpen = removed
-    ? (extra) => `<div class="ex-rail-body${extra.cls || ''}"${extra.attrs || ''}>`
-    : (extra) => `<div class="ex-rail-body swipe-wrap${extra.cls || ''}"${extra.attrs || ''}>${exDeleteBtnHtml(i)}<div class="ex-body-face swipe-face">`;
-  const wrapClose = removed ? '</div>' : '</div></div>';
+  // Completed exercises aren't deletable here — whole-exercise delete lives in
+  // the active exercise's 3-dot menu. Set rows inside still swipe to delete.
+  const wrapOpen = (extra) => `<div class="ex-rail-body${extra.cls || ''}"${extra.attrs || ''}>`;
+  const wrapClose = '</div>';
 
   if (expanded) {
     return `
@@ -274,6 +266,7 @@ function completedRowHtml(ex, i) {
 }
 
 const TRASH_SVG = '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14M10 11v6M14 11v6"/></svg>';
+const DOTS_SVG = '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>';
 
 function setDeleteBtnHtml(exIdx, si) {
   return `<button type="button" class="set-delete" data-act="delete-set" data-del-set="${exIdx},${si}" aria-label="Delete set" tabindex="-1">${TRASH_SVG}</button>`;

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v30';
+const VERSION = 'v31';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',

--- a/styles.css
+++ b/styles.css
@@ -304,15 +304,13 @@
   .rail-eyebrow { color: var(--text-dim); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
   .rail-eyebrow.active { color: var(--accent); }
   .rail-eyebrow.done { color: var(--success); }
-  .skip-ex-btn { flex-shrink: 0; }
 
   /* Tap an up-next exercise to make it active */
   .ex-rail-body.selectable { cursor: pointer; -webkit-tap-highlight-color: transparent; }
   .ex-rail-body.selectable:active { opacity: 0.7; }
 
   /* Just-completed exercise lingering in place before it files away */
-  .ex-rail-step.linger .ex-rail-body,
-  .ex-rail-step.linger .ex-body-face {
+  .ex-rail-step.linger .ex-rail-body {
     animation: wt-linger-in 260ms ease-out;
   }
   @keyframes wt-linger-in { from { background: var(--success-dim); } to { background: transparent; } }
@@ -488,32 +486,41 @@
     display: flex; align-items: center; justify-content: center;
     border: 0; border-radius: 11px; background: var(--danger);
     color: white; cursor: pointer; z-index: 0;
+    /* Hidden until the row is actually being swiped, so it can't peek through
+       behind the face during re-render / reorder animations. */
+    opacity: 0;
   }
+  .set-row.swipe-wrap.swiping .set-delete,
+  .set-row.swipe-wrap.revealed .set-delete { opacity: 1; }
 
-  /* Swipe-to-reveal delete on whole exercise rows — removes the exercise
-     from the workout and from the program going forward. The body is the
-     swipe container, so the sliding content clips at its own edge and never
-     crosses into the rail-circle column. */
-  .ex-rail-body.swipe-wrap {
-    position: relative; touch-action: pan-y;
-    clip-path: inset(-6px 0 -6px 0);
+  /* Exercise overflow (3-dot) menu on the active exercise */
+  .ex-menu-wrap { position: relative; }
+  .ex-menu-btn {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 32px; height: 28px; padding: 0;
+    border: 1px solid var(--border); border-radius: 8px;
+    background: var(--card); color: var(--text-dim);
+    cursor: pointer; -webkit-tap-highlight-color: transparent;
   }
-  .ex-rail-body.swipe-wrap > .ex-body-face {
-    position: relative; z-index: 1;
-    background: var(--card);
-    transition: transform 0.22s cubic-bezier(.2,.7,.2,1);
-    will-change: transform;
+  .ex-menu-btn:active { background: var(--accent-dim); color: var(--accent); }
+  .ex-menu {
+    display: none;
+    position: absolute; top: calc(100% + 6px); right: 0; z-index: 20;
+    min-width: 176px;
+    background: var(--card); border: 1px solid var(--border);
+    border-radius: 12px; padding: 6px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.28);
   }
-  .ex-rail-body.swipe-wrap.revealed > .ex-body-face { transform: translateX(-72px); }
-  .ex-delete {
-    /* bottom matches the body's padding-bottom so the button spans exactly
-       the face-covered area */
-    position: absolute; top: 0; right: 0; bottom: 18px; width: 72px;
-    display: flex; align-items: center; justify-content: center;
-    border: 0; border-radius: 11px; background: var(--danger);
-    color: white; cursor: pointer; z-index: 0;
+  .ex-menu-wrap.open .ex-menu { display: block; }
+  .ex-menu-item {
+    display: block; width: 100%; text-align: left;
+    padding: 10px 12px; border: 0; border-radius: 8px;
+    background: transparent; color: var(--text);
+    font-family: inherit; font-size: 15px; font-weight: 600;
+    cursor: pointer; -webkit-tap-highlight-color: transparent;
   }
-  .ex-rail-step:last-child .ex-rail-body.swipe-wrap > .ex-delete { bottom: 0; }
+  .ex-menu-item:active { background: var(--bg); }
+  .ex-menu-item.danger { color: var(--danger); }
 
   /* Drag-to-reorder upcoming exercises via the dots handle */
   .drag-handle {


### PR DESCRIPTION
…h flicker

Replaces the active exercise's Skip button with a 3-dot overflow menu offering Delete and Skip. Delete removes the whole exercise via the existing removeExerciseFromWorkout (drops it from the session and the saved program/library while keeping any already-logged sets); Skip keeps its prior behaviour. The menu closes on outside-tap or Escape.

Per product direction, swipe-to-delete now applies to SET rows only: the whole-exercise swipe-to-delete added alongside drag-to-reorder is removed so a swipe unambiguously deletes a set, and exercise deletion goes through the menu. Drag-to-reorder and add-exercise are unchanged.

Also fixes the flicker where the set-row delete (trash) button peeked through behind the row face during the rail reorder/ghost animation when an exercise completed: it's now hidden unless the row is actively being swiped or revealed.