### PR TITLE
Allow backfilling workouts on past calendar days

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -326,6 +326,11 @@ function onClick(e) {
     startWorkout(parseInt(e.target.dataset.startDay, 10));
     return;
   }
+  // "Log" on a past calendar day — start a backfill dated to that day.
+  if (e.target.dataset.logDay != null) {
+    startWorkout(parseInt(e.target.dataset.logDay, 10), parseInt(e.target.dataset.logDate, 10));
+    return;
+  }
   const pickEl = e.target.closest && e.target.closest('[data-toggle-pick]');
   if (pickEl) {
     const i = parseInt(pickEl.dataset.togglePick, 10);

--- a/js/views/today.js
+++ b/js/views/today.js
@@ -133,12 +133,29 @@ function selectedDayDetailHtml(currentWeek) {
         html += allDoneTodayCardHtml();
       }
     }
-  } else if (!sessions.length && !isToday) {
-    html += `<div class="card compact"><div class="subtle">Nothing logged on this day.</div></div>`;
+  } else if (!isToday) {
+    html += pastDayLogHtml(ts);
   } else if (!sessions.length && isToday && programIsComplete()) {
     html += `<div class="card compact"><div class="subtle">Program finished &mdash; start it again or pick a new one in Settings.</div></div>`;
   }
 
+  return html;
+}
+
+/* A past calendar day — let the user backfill a workout they did but never
+   logged, to keep their history complete. Offers the workout types not already
+   logged on that day. */
+function pastDayLogHtml(ts) {
+  if (state.active) {
+    return `<div class="card compact"><div class="subtle">Finish your active workout before logging a past day.</div></div>`;
+  }
+  const loggedIdxs = sessionsOnDate(ts).map(s => s.dayIndex);
+  const due = state.program.template
+    .map((d, i) => ({ d, i }))
+    .filter(({ i }) => !loggedIdxs.includes(i));
+  if (!due.length) return '';
+  let html = due.map(({ d, i }) => pickCardHtml(d, i, ts)).join('');
+  html += `<div class="faint cal-hint">Missed one? Add a workout you did on this day to your history.</div>`;
   return html;
 }
 
@@ -151,10 +168,13 @@ function allDoneTodayCardHtml() {
 }
 
 /* A workout still due this week — tap to preview exercises, Start to begin. */
-function pickCardHtml(day, i) {
+function pickCardHtml(day, i, forDate) {
   const expanded = expandedPickIdx === i;
   const exCount = day.exercises.length;
   const setTotal = day.exercises.reduce((n, e) => n + e.sets, 0);
+  const actionBtn = forDate != null
+    ? `<button class="btn small" data-log-day="${i}" data-log-date="${forDate}">Log</button>`
+    : `<button class="btn small" data-start-day="${i}">Start</button>`;
   return `
     <div class="card pick-card" data-toggle-pick="${i}">
       <div class="pick-head">
@@ -163,7 +183,7 @@ function pickCardHtml(day, i) {
           <div class="pick-name">${esc(day.name || 'Workout ' + (i + 1))}</div>
           <div class="pick-meta">${exCount} exercise${exCount === 1 ? '' : 's'} &middot; ${setTotal} sets</div>
         </div>
-        <button class="btn small" data-start-day="${i}">Start</button>
+        ${actionBtn}
         <span class="pick-chev">${expanded ? '&#9662;' : '&#9656;'}</span>
       </div>
       ${expanded ? `

--- a/js/views/workout.js
+++ b/js/views/workout.js
@@ -40,8 +40,9 @@ Views.workout = function() {
     </datalist>
     <div class="workout-top">
       <div style="margin-bottom:13px;">
-        <div class="section-label" style="margin-bottom:3px;">Week ${a.weekIndex + 1}</div>
+        <div class="section-label" style="margin-bottom:3px;">${a.logDate ? 'Backdated log' : 'Week ' + (a.weekIndex + 1)}</div>
         <h1 class="workout-day-title">${esc(a.dayName)}</h1>
+        ${a.logDate ? `<div class="faint" style="margin-top:3px;">Logging for ${esc(new Date(a.logDate).toLocaleDateString(undefined, { weekday: 'long', month: 'short', day: 'numeric' }))}</div>` : ''}
       </div>
       <div class="dots">${dots}</div>
     </div>

--- a/js/workouts.js
+++ b/js/workouts.js
@@ -1,8 +1,13 @@
 /* ---------- Workout actions ---------- */
-function startWorkout(dayIndex) {
-  if (programIsComplete()) return;
-  if (dayIsDoneToday(dayIndex)) return;
+// logDate (a timestamp on a past calendar day) starts a backfill: the finished
+// session is dated to that day so missed workouts can be added to history.
+function startWorkout(dayIndex, logDate) {
   if (state.active) return;
+  const backfill = logDate != null;
+  if (!backfill) {
+    if (programIsComplete()) return;
+    if (dayIsDoneToday(dayIndex)) return;
+  }
   const day = state.program.template[dayIndex];
   if (!day) return;
   editingSet = null;
@@ -10,15 +15,21 @@ function startWorkout(dayIndex) {
   lingeringExIdx = null;
   completedCollapsed = true;
   addingExercise = false;
-  selectedWeekIndex = state.currentRun.weekIndex || 0;
-  expandedDayKey = dayKey(selectedWeekIndex, dayIndex);
+  // Stamp backfills at midday so they sort sensibly within the chosen day.
+  const ld = backfill ? dayStartTs(logDate) + 12 * 3600000 : null;
+  const weekIndex = backfill
+    ? Math.max(0, calendarWeekOfTs(ld))
+    : (state.currentRun.weekIndex || 0);
+  selectedWeekIndex = weekIndex;
+  expandedDayKey = dayKey(weekIndex, dayIndex);
   state.active = {
     programId: state.activeProgramId || null,
     programName: state.program.name,
-    weekIndex: state.currentRun.weekIndex,
+    weekIndex,
     dayIndex,
     dayName: day.name || ('Workout ' + (dayIndex + 1)),
-    startedAt: Date.now(),
+    startedAt: ld || Date.now(),
+    logDate: ld,
     activeExIdx: 0,
     exercises: day.exercises.map(e => ({
       name: e.name,
@@ -526,7 +537,7 @@ function endWorkoutFlow() {
   // workout complete for today. The rest are simply dropped.
   showModal({
     title: 'Finish workout?',
-    body: 'Only the exercises you\'ve completed will be logged. This workout will be marked complete for today.',
+    body: 'Only the exercises you\'ve completed will be logged; the rest are dropped.',
     confirmText: 'Finish',
     onConfirm: () => {
       closeModal();
@@ -602,6 +613,12 @@ function finishWorkout() {
   // or celebration — the original workout already earned those.
   if (a.editOfDate != null) {
     finishSessionEdit(a);
+    return;
+  }
+  // Backfilled (past-day) workout: save it to history on its own date, with no
+  // streak / XP / celebration — it's a history entry, not today's session.
+  if (a.logDate != null) {
+    finishBackfillWorkout(a);
     return;
   }
   persistAddedExerciseTargets(a);
@@ -806,6 +823,49 @@ function finishSessionEdit(a) {
   lingeringExIdx = null;
   completedCollapsed = true;
   addingExercise = false;
+  state.tab = 'today';
+  save();
+  render();
+}
+
+// Save a backfilled (past-day) workout straight to history. No XP, streak or
+// celebration — it just records what was done on that day. Only the completed
+// exercises are kept; if nothing was logged the workout is dropped.
+function finishBackfillWorkout(a) {
+  persistAddedExerciseTargets(a);
+  const sessionExercises = a.exercises.filter(e => e.sets.length > 0 || e.skipped);
+  if (sessionExercises.length) {
+    state.sessions.push({
+      date: a.logDate,
+      programId: a.programId || state.activeProgramId || null,
+      programName: a.programName || (state.program && state.program.name) || '',
+      weekIndex: a.weekIndex,
+      dayIndex: a.dayIndex,
+      dayName: a.dayName,
+      durationMs: 0,
+      fullyComplete: a.exercises.every(exerciseIsResolved),
+      exercises: sessionExercises.map(e => ({
+        name: e.name,
+        sets: e.sets,
+        skipped: !!e.skipped,
+        skippedAt: e.skippedAt || null,
+        removed: !!e.removed,
+        targetSets: e.targetSets,
+        targetReps: e.targetReps
+      }))
+    });
+    // Keep the log ordered by date so the calendar/history stays consistent.
+    state.sessions.sort((x, y) => x.date - y.date);
+    selectedDateTs = dayStartTs(a.logDate);
+  }
+  syncCalendarRun();
+  state.active = null;
+  editingSet = null;
+  expandedExIdx = null;
+  lingeringExIdx = null;
+  completedCollapsed = true;
+  addingExercise = false;
+  state.celebration = null;
   state.tab = 'today';
   save();
   render();

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,7 @@
    over without users having to close every tab.
 
    IMPORTANT: bump VERSION on every release so old caches drop. */
-const VERSION = 'v33';
+const VERSION = 'v34';
 const CACHE = `wt-${VERSION}`;
 const SHELL = [
   './',


### PR DESCRIPTION
Tapping a past day on the Program calendar now offers the workout types not yet logged that day, each with a 'Log' button. Logging reuses the normal workout flow but stamps the finished session with the chosen day's date (startWorkout gains an optional logDate; finishWorkout routes to a new finishBackfillWorkout). Backfills are pure history entries — no streak, XP or celebration — and only the completed exercises are saved. The workout header shows a 'Logging for <date>' note while backdating.

The once-per-day start gate still blocks repeating a workout already done today, but does not block backfilling earlier days.